### PR TITLE
Add Quill archivist agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /chatlogs
 fenra_config.txt
 chat_log.txt
+summary.txt
+archive/

--- a/fenra_config.txt
+++ b/fenra_config.txt
@@ -6,16 +6,25 @@ chat_style=formal debate
 
 [Beluga]
 model=stable-beluga:13b
+role=ruminator
 
 [Samantha]
 model=samantha-mistral:7b
 role_prompt=You are the empath. Focus on emotional insight and encouragement.
+role=ruminator
 
 [Seeker]
 model=deepseek-r1:8b
 temperature=0.8
+role=ruminator
 
 [Hermes]
 model=nous-hermes2:34b
 max_tokens=200
 active=false
+role=ruminator
+
+[Quill]
+model=neural-chat:7b
+role=archivist
+role_prompt=You are Quill, the Archivist of Fenra. You do not participate in conversation. Your sole purpose is to observe, compress, and preserve. After each conversational cycle, you take the full transcript and create a concise summary that retains key themes, names, and important insights. Additionally, you store the full transcript for future use.


### PR DESCRIPTION
## Summary
- introduce base `Agent` with `Ruminator` and `Archivist` subclasses
- implement summarization/archiving logic in `Archivist`
- adjust conductor to instantiate agents based on new `role` field
- run Quill after each ruminator cycle, replacing context with the summary
- update config file with roles and add Quill settings
- ignore summary and archive outputs

## Testing
- `python -m py_compile ai_model.py conductor.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686429ea0abc832dabd43e23f1b4a214