### PR TITLE
Add configurable watchdog timeout

### DIFF
--- a/ai_model.py
+++ b/ai_model.py
@@ -14,11 +14,13 @@ class AIModel:
         temperature: float = 0.7,
         max_tokens: int = 300,
         chat_style: Optional[str] = None,
+        watchdog_timeout: int = 300,
     ) -> None:
         self.name = name
         self.model_id = model_id
         self.temperature = temperature
         self.max_tokens = max_tokens
+        self.watchdog_timeout = watchdog_timeout
 
         parts = [topic_prompt]
         if role_prompt:
@@ -54,7 +56,10 @@ class AIModel:
 
         try:
             resp = requests.post(
-                "http://localhost:11434/api/generate", json=payload, stream=True
+                "http://localhost:11434/api/generate",
+                json=payload,
+                stream=True,
+                timeout=self.watchdog_timeout,
             )
         except requests.RequestException as exc:
             raise RuntimeError(f"Failed to connect to Ollama: {exc}") from exc
@@ -100,6 +105,7 @@ class Agent:
             temperature=float(config.get("temperature", 0.7)),
             max_tokens=int(config.get("max_tokens", 300)),
             chat_style=config.get("chat_style"),
+            watchdog_timeout=int(config.get("watchdog_timeout", 300)),
         )
 
     def step(self, context: List[Dict[str, str]]):

--- a/conductor.py
+++ b/conductor.py
@@ -34,11 +34,13 @@ def load_config(path: str):
         temperature_global = parser.getfloat("global", "temperature", fallback=0.7)
         max_tokens_global = parser.getint("global", "max_tokens", fallback=300)
         chat_style_global = parser.get("global", "chat_style", fallback=None)
+        watchdog_global = parser.getint("global", "watchdog_timeout", fallback=300)
     else:
         topic_prompt_global = None
         temperature_global = 0.7
         max_tokens_global = 300
         chat_style_global = None
+        watchdog_global = 300
 
     agents = []
     for section in sections:
@@ -57,6 +59,7 @@ def load_config(path: str):
         temperature = parser.getfloat(section, "temperature", fallback=temperature_global)
         max_tokens = parser.getint(section, "max_tokens", fallback=max_tokens_global)
         chat_style = parser.get(section, "chat_style", fallback=chat_style_global)
+        watchdog = parser.getint(section, "watchdog_timeout", fallback=watchdog_global)
 
         topic_prompt = parser.get(section, "topic_prompt", fallback=topic_prompt_global)
         if topic_prompt is None:
@@ -71,6 +74,7 @@ def load_config(path: str):
             "temperature": temperature,
             "max_tokens": max_tokens,
             "chat_style": chat_style,
+            "watchdog_timeout": watchdog,
         }
 
         if role == "archivist":

--- a/fenra_config.txt
+++ b/fenra_config.txt
@@ -2,6 +2,7 @@
 topic_prompt = Assume you are part of an AI think tank exploring the philosophical and functional aspects of artificial general intelligence. Discuss autonomy, cooperation, recursion, and the implications of synthetic consciousness.
 temperature = 0.7
 max_tokens = 300
+watchdog_timeout = 300
 
 [Beluga]
 model = stable-beluga:13b


### PR DESCRIPTION
## Summary
- add `watchdog_timeout` setting to `AIModel` for request timeout
- pass watchdog value from config in `Agent` and `conductor.load_config`
- default to 300 seconds (5 minutes) and document in `fenra_config.txt`

## Testing
- `python -m py_compile ai_model.py conductor.py`

------
https://chatgpt.com/codex/tasks/task_e_686469073b14832d945e721b6b1c767f