### PR TITLE
Update summary logging and watchdog average

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 fenra_config.txt
 chat_log.txt
 summary.txt
+summary_log.txt
 archive/
 __pycache__/

--- a/ai_model.py
+++ b/ai_model.py
@@ -151,4 +151,11 @@ class Archivist(Agent):
         except OSError as exc:
             print(f"Failed to write summary: {exc}")
 
+        # Append summary with timestamp to running log
+        try:
+            with open("summary_log.txt", "a", encoding="utf-8") as f:
+                f.write(f"[{ts}] {summary}\n{'-' * 80}\n")
+        except OSError as exc:
+            print(f"Failed to update summary log: {exc}")
+
         return summary

--- a/runtime_utils.py
+++ b/runtime_utils.py
@@ -21,10 +21,10 @@ class AITimeTracker:
         self.data.append(ai_seconds)
 
     def average(self) -> float:
-        """Return the average AI Seconds; fallback to 1.0 if none."""
-        if not self.data:
-            return 1.0
-        return sum(self.data) / len(self.data)
+        """Return the rolling average AI Seconds with a 300s baseline."""
+        total = sum(self.data) + 300
+        count = len(self.data) + 1
+        return total / count
 
 
 def parse_model_size(model_id: str) -> float:


### PR DESCRIPTION
## Summary
- keep a running log of summaries with timestamps
- factor a 300 second starting baseline into watchdog averages
- ignore new summary log file

## Testing
- `python -m py_compile ai_model.py conductor.py runtime_utils.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686538c778c8832da920b0b6d8812ac7