### PR TITLE
Log JSON payloads when debug enabled

### DIFF
--- a/ai_model.py
+++ b/ai_model.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import requests
 from typing import List, Dict, Optional
 
@@ -63,6 +64,8 @@ class AIModel:
             "max_tokens": self.max_tokens,
         }
         self.logger.debug("Sending generation request")
+        if self.logger.isEnabledFor(logging.DEBUG):
+            self.logger.debug("Payload to Ollama:\n%s", json.dumps(payload, indent=2))
         try:
             resp = requests.post(
                 "http://localhost:11434/api/generate",

--- a/conductor.py
+++ b/conductor.py
@@ -139,9 +139,12 @@ def ensure_models_available(model_ids: List[str]) -> None:
             continue
         logger.info("Model %s not found locally. Downloading...", mid)
         try:
+            if logger.isEnabledFor(logging.DEBUG):
+                payload = {"name": mid, "stream": False}
+                logger.debug("Payload to Ollama:\n%s", json.dumps(payload, indent=2))
             pull_resp = requests.post(
                 PULL_URL,
-                json={"name": mid, "stream": False},
+                json=payload,
             )
         except requests.RequestException as exc:
             logger.error("Failed to pull model %s: %s", mid, exc)

--- a/runtime_utils.py
+++ b/runtime_utils.py
@@ -114,6 +114,8 @@ def generate_with_watchdog(
     def worker() -> None:
         start = time.time()
         try:
+            if logger.isEnabledFor(logging.DEBUG):
+                logger.debug("Payload to Ollama:\n%s", json.dumps(payload, indent=2))
             resp = requests.post(
                 "http://localhost:11434/api/generate",
                 json=payload,


### PR DESCRIPTION
## Summary
- show request JSON payloads in AIModel
- display pull request payload when pulling models
- log payloads in the watchdog helper

## Testing
- `python -m py_compile ai_model.py conductor.py runtime_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_68698b715764832d8291eb0a4c39e19e