### PR TITLE
Add ability to add new models via UI

### DIFF
--- a/fenra_ui.py
+++ b/fenra_ui.py
@@ -1,14 +1,15 @@
 import tkinter as tk
-from tkinter import scrolledtext
+from tkinter import scrolledtext, simpledialog, messagebox
 
 
 class FenraUI:
     """Simple UI for displaying output and listing AIs."""
 
-    def __init__(self, agents):
+    def __init__(self, agents, add_agent_callback=None):
         self.root = tk.Tk()
         self.root.title("Fenra")
         self.agents = agents
+        self.add_agent_callback = add_agent_callback
 
         # Left side for console output
         self.output = scrolledtext.ScrolledText(self.root, state="disabled", width=80, height=24)
@@ -27,6 +28,36 @@ class FenraUI:
         self.info_var = tk.StringVar()
         self.info_label = tk.Label(right, textvariable=self.info_var, justify=tk.LEFT, anchor="w")
         self.info_label.pack(fill=tk.BOTH, expand=True)
+
+        self.add_button = tk.Button(right, text="Add Model", command=self._prompt_add)
+        self.add_button.pack(fill=tk.X)
+
+    def _prompt_add(self):
+        """Prompt the user for a new agent and add it via callback."""
+        if not self.add_agent_callback:
+            return
+
+        name = simpledialog.askstring("Add Model", "Name:", parent=self.root)
+        if not name:
+            return
+
+        model = simpledialog.askstring("Add Model", "Model ID:", parent=self.root)
+        if not model:
+            return
+
+        role = simpledialog.askstring("Add Model", "Role Prompt:", parent=self.root)
+        if role is None:
+            role = ""
+
+        try:
+            agent = self.add_agent_callback(name, model, role)
+        except Exception as exc:  # noqa: BLE001
+            messagebox.showerror("Error", str(exc), parent=self.root)
+            return
+
+        if agent is not None:
+            self.agents.append(agent)
+            self.listbox.insert(tk.END, agent.name)
 
     def _on_select(self, event):
         selection = event.widget.curselection()


### PR DESCRIPTION
## Summary
- add `load_global_defaults()` to parse default model configuration
- create callback in `Conductor` for adding a new agent at runtime
- extend `FenraUI` with an "Add Model" button and dialogs to gather user input

## Testing
- `python -m py_compile ai_model.py conductor.py fenra_ui.py runtime_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_686befd3c918832d958312702e1d8ae5