### PR TITLE
Simplify tool agent checks

### DIFF
--- a/conductor.py
+++ b/conductor.py
@@ -108,20 +108,7 @@ def load_config(path: str):
                 role_prompt=role_prompt,
                 config=cfg,
             )
-            if agent.model.supports_tools:
-                agents.append(agent)
-            else:
-                logger.warning(
-                    "Model %s lacks tool capability; using ruminator instead", model_id
-                )
-                agents.append(
-                    Ruminator(
-                        name=section,
-                        model_name=model_id,
-                        role_prompt=role_prompt,
-                        config=cfg,
-                    )
-                )
+            agents.append(agent)
         else:
             agents.append(
                 Ruminator(


### PR DESCRIPTION
## Summary
- remove fallback logic when loading tool-enabled agents
- always return True from `model_supports_tools`
- remove guard in `ToolAgent.step`
- include tool call IDs when sending tool results

## Testing
- `python -m py_compile fenra/*.py`

------
https://chatgpt.com/codex/tasks/task_e_686c1b93f6e8832dbe7141bb195ba329