### PR TITLE
Handle <think> markup in model output

### DIFF
--- a/ai_model.py
+++ b/ai_model.py
@@ -9,6 +9,7 @@ from runtime_utils import (
     create_object_logger,
     generate_with_watchdog,
     parse_model_size,
+    strip_think_markup,
     WATCHDOG_TRACKER,
 )
 
@@ -79,6 +80,7 @@ class AIModel:
             parse_model_size(self.model_id),
             WATCHDOG_TRACKER,
         )
+        result_text = strip_think_markup(result_text)
         self.logger.debug("Generated %d characters", len(result_text))
         return result_text
 
@@ -110,6 +112,11 @@ class AIModel:
         except json.JSONDecodeError as exc:  # noqa: BLE001
             self.logger.error("Invalid JSON from Ollama: %s", exc)
             raise RuntimeError("Invalid JSON from Ollama") from exc
+        message = data.get("message")
+        if isinstance(message, dict):
+            content = message.get("content")
+            if isinstance(content, str):
+                message["content"] = strip_think_markup(content)
         return data
 
 

--- a/runtime_utils.py
+++ b/runtime_utils.py
@@ -130,6 +130,11 @@ def parse_response(resp: requests.Response) -> str:
     return data.get("response", "")
 
 
+def strip_think_markup(text: str) -> str:
+    """Return text with any <think>...</think> sections removed."""
+    return re.sub(r"<think>.*?</think>", "", text, flags=re.DOTALL | re.IGNORECASE)
+
+
 def kill_thread(thread: threading.Thread) -> None:
     """Forcefully stop a thread by raising SystemExit within it."""
     ident: Optional[int] = thread.ident


### PR DESCRIPTION
## Summary
- skip hidden `<think>` blocks when getting model responses
- filter content from chat completions

## Testing
- `python -m py_compile ai_model.py runtime_utils.py tools.py conductor.py fenra_ui.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687014405714832d89c50c9efe231eab