### PR TITLE
Improve watchdog and logging

### DIFF
--- a/fenra_ui.py
+++ b/fenra_ui.py
@@ -84,7 +84,7 @@ class FenraUI:
             f"Name: {agent.name}\n"
             f"Model: {agent.model_name}\n"
             f"Role: {role}\n"
-            f"Parameters: {params}B\n"
+            f"Disk Size: {params} GB\n"
             f"Role Prompt:\n{agent.role_prompt}"
         )
         self.info_var.set(info)


### PR DESCRIPTION
## Summary
- mirror logging to both stdout and per-object log files
- base watchdog timing on model's disk size via `ollama list`
- retry Ollama requests on timeout instead of restarting threads
- show model disk size in the UI

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_68702a4faed4832dbee8e0054f26e6b5