### PR TITLE
Update prompt assembly

### DIFF
--- a/ai_model.py
+++ b/ai_model.py
@@ -41,10 +41,11 @@ class AIModel:
         )
 
         parts = [topic_prompt]
-        if role_prompt:
-            parts.append(role_prompt)
         if chat_style:
             parts.append(f"Use a {chat_style} tone.")
+        parts.append(f"Your name is {name}.")
+        if role_prompt:
+            parts.append(role_prompt)
         self.base_prompt = "\n".join(parts)
 
         # system_prompt is optional and comes from config
@@ -52,13 +53,14 @@ class AIModel:
 
     def build_prompt(self, chat_log: List[Dict[str, str]]) -> str:
         """Assemble a prompt from system prompt and chat history."""
-        lines = [self.base_prompt, f"Your name is {self.name}."]
+        lines = [self.base_prompt, "=====Chat Begins====="]
         for entry in chat_log:
             sender = entry.get("sender", "")
             message = entry.get("message", "")
             timestamp = entry.get("timestamp", "")
             lines.append(f"[{timestamp}] {sender}: {message}")
             lines.append("-" * 80)
+        lines.append("=====Chat Ends=====")
         lines.append(
             "The above message is the full chat log. Each message is separated by a series of hyphens. The names of the speakers are indicated before the message."
         )


### PR DESCRIPTION
## Summary
- build base prompt with agent name at the end
- wrap chat messages between `=====Chat Begins=====` and `=====Chat Ends=====`
- adjust prompt creation order so role prompt follows the agent's name

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_687039e3d424832da350692e68d4ed30