### PR TITLE
Fix num_ctx usage for Ollama API

### DIFF
--- a/ai_model.py
+++ b/ai_model.py
@@ -79,7 +79,7 @@ class AIModel:
             "prompt": prompt,
             "stream": False,
             "temperature": self.temperature,
-            "max_tokens": self.max_tokens,
+            "options": {"num_ctx": self.max_tokens},
         }
         if self.system_prompt:
             payload["system"] = self.system_prompt
@@ -105,7 +105,7 @@ class AIModel:
             "model": self.model_id,
             "messages": messages,
             "temperature": self.temperature,
-            "max_tokens": self.max_tokens,
+            "options": {"num_ctx": self.max_tokens},
             "stream": False,
         }
         if tools:


### PR DESCRIPTION
## Summary
- send max token value using `options.num_ctx` rather than `max_tokens`

## Testing
- `python -m py_compile ai_model.py conductor.py fenra_ui.py runtime_utils.py tools.py`


------
https://chatgpt.com/codex/tasks/task_e_687348767b30832d96f5ee690c31bc7d