### PR TITLE
Move role/topic prompts to system field

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,9 @@ chat_log_new.txt
 chat_log_fringe.txt
 chat_log_pulse.txt
 chat_log_veil.txt
+chat_log_groupA.txt
+chat_log_groupB.txt
+chat_log_groupC.txt
+chat_log_groupD.txt
+chat_log_groupE.txt
+chat_log_groupF.txt


### PR DESCRIPTION
## Summary
- keep role and topic prompts out of the main context
- attach role and topic prompts to the `system` field for both chat and generate APIs
- compose system message for ToolAgent with role and topic prompts
- join role and topic prompts with a space instead of `||`

## Testing
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_6873df5b64ac832d80064a56bd4120fe