### PR TITLE
cache model size

### DIFF
--- a/ai_model.py
+++ b/ai_model.py
@@ -31,6 +31,7 @@ class AIModel:
     ) -> None:
         self.name = name
         self.model_id = model_id
+        self.model_size = parse_model_size(model_id)
         self.temperature = temperature
         self.max_tokens = max_tokens
         self.watchdog_timeout = watchdog_timeout
@@ -101,7 +102,7 @@ class AIModel:
             self.logger.debug("Payload to Ollama:\n%s", json.dumps(payload, indent=2))
         result_text = generate_with_watchdog(
             payload,
-            parse_model_size(self.model_id),
+            self.model_size,
             WATCHDOG_TRACKER,
         )
         result_text = strip_think_markup(result_text)
@@ -137,7 +138,7 @@ class AIModel:
             self.logger.debug("Payload to Ollama:\n%s", json.dumps(payload, indent=2))
         result_text = generate_with_watchdog(
             payload,
-            parse_model_size(self.model_id),
+            self.model_size,
             WATCHDOG_TRACKER,
         )
         try:


### PR DESCRIPTION
## Summary
- cache model size by calling `parse_model_size` once in `AIModel.__init__`
- reuse the cached model size during generation

## Testing
- `python -m py_compile ai_model.py conductor.py fenra_ui.py tools.py runtime_utils.py`
- `python conductor.py --help` *(fails: ollama server not running)*

------
https://chatgpt.com/codex/tasks/task_e_6875127e2b2c832d9e0a1ecd4ee56f05