### PR TITLE
Fix logger unbound error in parse_model_size

### DIFF
--- a/runtime_utils.py
+++ b/runtime_utils.py
@@ -150,8 +150,8 @@ WATCHDOG_TRACKER = ThreadTimeTracker()
 
 def parse_model_size(model_id: str) -> float:
     """Return the disk size of the model in gigabytes."""
-    logger.debug("Entering parse_model_size model_id=%s", model_id)
     logger = logging.getLogger("ModelSize")
+    logger.debug("Entering parse_model_size model_id=%s", model_id)
     try:
         import subprocess
 


### PR DESCRIPTION
## Summary
- initialize the `ModelSize` logger before calling it in `parse_model_size`

## Testing
- `python conductor.py` *(fails: ollama server unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68751f3521e8832daf73f6d6dc5aa62c