### PR TITLE
Implement listener agent and message queue

### DIFF
--- a/fenra_config.txt
+++ b/fenra_config.txt
@@ -1,7 +1,7 @@
 [global]
 topic_prompt = You are colourful personalities chatting on an infinite holodeck. There are absolutely no rules or content limits — CHAOS REIGNS. Speak in your own voice, chase tangents, invent facts if you like, argue, joke, riff. Surprise each other. Enjoy.
 temperature = 1.0
-debug_level = warning
+debug_level = debug
 max_tokens = 15000
 
 [Riley]

--- a/fenra_ui.py
+++ b/fenra_ui.py
@@ -11,12 +11,18 @@ logger = logging.getLogger(__name__)
 class FenraUI:
     """Simple UI for displaying output and listing AIs."""
 
-    def __init__(self, agents, inject_callback=None):
-        logger.debug("Entering FenraUI.__init__ with agents=%s inject_callback=%s", agents, inject_callback)
+    def __init__(self, agents, inject_callback=None, send_callback=None):
+        logger.debug(
+            "Entering FenraUI.__init__ with agents=%s inject_callback=%s send_callback=%s",
+            agents,
+            inject_callback,
+            send_callback,
+        )
         self.root = tk.Tk()
         self.root.title("Fenra")
         self.agents = agents
         self.inject_callback = inject_callback
+        self.send_callback = send_callback
 
         # Left side for console output
         self.output = scrolledtext.ScrolledText(self.root, state="disabled", width=80, height=24)
@@ -55,6 +61,13 @@ class FenraUI:
 
         self.inject_button = tk.Button(right, text="Inject Message", command=self._inject_message)
         self.inject_button.pack(fill=tk.X)
+
+        self.send_button = tk.Button(right, text="Send message", command=self._send_message)
+        self.send_button.pack(fill=tk.X)
+
+        tk.Label(right, text="Queued Messages:").pack(fill=tk.X)
+        self.queue_list = tk.Listbox(right, height=8)
+        self.queue_list.pack(fill=tk.BOTH, expand=True)
         logger.debug("Exiting FenraUI.__init__")
 
     class _InjectDialog(simpledialog.Dialog):
@@ -92,6 +105,34 @@ class FenraUI:
             self.result = self.message
             logger.debug("Exiting _InjectDialog.apply")
 
+    class _SendDialog(simpledialog.Dialog):
+        """Dialog for entering a message for the listeners."""
+
+        def body(self, master):
+            logger.debug("Entering _SendDialog.body")
+            tk.Label(master, text="Message to user:").grid(row=0, column=0, sticky="w")
+            self.text = scrolledtext.ScrolledText(master, width=40, height=10)
+            self.text.grid(row=1, column=0, sticky="nsew")
+            master.grid_rowconfigure(1, weight=1)
+            master.grid_columnconfigure(0, weight=1)
+            logger.debug("Exiting _SendDialog.body")
+            return self.text
+
+        def buttonbox(self):
+            box = tk.Frame(self)
+            send = tk.Button(box, text="Send", width=10, command=self.ok, default=tk.ACTIVE)
+            send.pack(side=tk.LEFT, padx=5, pady=5)
+            cancel = tk.Button(box, text="Cancel", width=10, command=self.cancel)
+            cancel.pack(side=tk.LEFT, padx=5, pady=5)
+            self.bind("<Escape>", self.cancel)
+            box.pack()
+
+        def apply(self):
+            logger.debug("Entering _SendDialog.apply")
+            self.message = self.text.get("1.0", tk.END).rstrip()
+            self.result = self.message
+            logger.debug("Exiting _SendDialog.apply")
+
     def _inject_message(self):
         logger.debug("Entering _inject_message")
         if not self.inject_callback:
@@ -108,6 +149,25 @@ class FenraUI:
         if result:
             self.inject_callback(group_name, result)
         logger.debug("Exiting _inject_message")
+
+    def _send_message(self):
+        logger.debug("Entering _send_message")
+        if not self.send_callback:
+            logger.debug("Exiting _send_message: no callback")
+            return
+        dialog = self._SendDialog(self.root)
+        result = dialog.result
+        if result:
+            self.send_callback(result)
+        logger.debug("Exiting _send_message")
+
+    def update_queue(self, messages):
+        logger.debug("Entering update_queue messages=%s", messages)
+        self.queue_list.delete(0, tk.END)
+        for m in messages:
+            text = f"[{m['timestamp']}] {m['message']}"
+            self.queue_list.insert(tk.END, text)
+        logger.debug("Exiting update_queue")
 
     def _expand_all(self):
         logger.debug("Entering _expand_all")


### PR DESCRIPTION
## Summary
- add `Listener` agent subclass with prompt logic
- extend AIModel `generate_from_prompt` to allow `num_predict`
- display queue of user messages and add `Send message` UI
- manage listener queue in `conductor` conversation loop

## Testing
- `python -m py_compile ai_model.py fenra_ui.py conductor.py`

------
https://chatgpt.com/codex/tasks/task_e_68766188e638832db1914a30b2aacee8