### PR TITLE
Improve listener behavior

### DIFF
--- a/conductor.py
+++ b/conductor.py
@@ -369,9 +369,7 @@ def main() -> None:
                             message_queue.pop(0)
                         ui.root.after(0, ui.update_queue, list(message_queue))
                     else:
-                        lines = [f"[{m['timestamp']}] {m['sender']}: {m['message']}" for m in current_log]
-                        ruminations = "\n".join(lines)
-                        reply = listener_ai.prompt_ais(ruminations, msg["message"])
+                        reply = listener_ai.prompt_ais(msg["message"])
                         ts = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
                         with chat_lock:
                             inject_queue.append({
@@ -455,6 +453,13 @@ def main() -> None:
                         "timestamp": timestamp,
                         "message": reply,
                         "groups": ai.groups,
+                    }
+                )
+                sent_messages.append(
+                    {
+                        "message": reply,
+                        "timestamp": timestamp,
+                        "epoch": time.time(),
                     }
                 )
             logger.info("%s: generated response", ai.name)


### PR DESCRIPTION
## Summary
- allow overriding temperature and system prompt when generating from a prompt
- check listener answers with temperature 0 and no system message
- simplify reminder prompt
- store outgoing messages for listener checks
- fix listener prompts per review comments

## Testing
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_6876beebcb1c832d859ba3fbe45bde7b