### PR TITLE
Improve listener response verification prompt

### DIFF
--- a/ai_model.py
+++ b/ai_model.py
@@ -423,22 +423,26 @@ class Listener(Agent):
 
     def check_answered(self, message: str, outputs: List[str]) -> bool:
         """Return True if the user's question appears answered."""
+        if not outputs:
+            return False
         for out in outputs:
             lines = [
-                f"A human said the following: {message}",
-                "",
-                f"The following response was sent: {out}",
-                "",
                 (
-                    "Was the human's messages responded to by the response? "
-                    "Only answer 'Yes' or 'No.'"
+                    "Below is a message receive from the humans and a message "
+                    "sent to the humans. Does the sent message respond to the "
+                    "received message? Only answer yes or no:"
                 ),
+                "-----------------",
+                f"Received Message: {message}",
+                "-----------------",
+                f"Sent Message: {out}",
             ]
             prompt = "\n".join(lines)
             wc = len(prompt.split())
             reply = self.model.generate_from_prompt(
                 prompt,
                 num_ctx=wc,
+                num_predict=3,
                 temperature=0.0,
                 system="",
             )


### PR DESCRIPTION
## Summary
- update listener yes/no prompt wording in `check_answered`
- set `num_predict` to 3 when verifying responses
- skip model call if there are no sent messages to check

## Testing
- `python -m py_compile ai_model.py conductor.py fenra_ui.py runtime_utils.py tools.py`


------
https://chatgpt.com/codex/tasks/task_e_6876dae9774c832da5652e492f000b11