### PR TITLE
Add messages_to_humans tracking

### DIFF
--- a/ai_model.py
+++ b/ai_model.py
@@ -453,14 +453,15 @@ class Listener(Agent):
                 return True
         return False
 
-    def prompt_ais(self, message: str) -> str:
+    def prompt_ais(self, transcript: str, message: str) -> str:
         """Ask other AIs to answer the user's question."""
         lines = ["-----Message from User-----"]
         lines.append(message)
+        lines.append("-----Message Log-----")
+        lines.append(transcript)
         lines.append("-----Your Instructions-----")
         lines.append(self.PROMPT_INSTRUCTIONS)
         prompt = "\n".join(lines)
-        wc = len(prompt.split())
         reply = self.model.generate_from_prompt(
             prompt,
             system="",

--- a/conductor.py
+++ b/conductor.py
@@ -320,6 +320,7 @@ def main() -> None:
     inject_queue: List[Dict[str, str]] = []
     message_queue: List[Dict[str, object]] = []
     sent_messages: List[Dict[str, object]] = []
+    messages_to_humans: List[Dict[str, object]] = []
     chat_lock = threading.Lock()
     threads: List[threading.Thread] = []
 
@@ -342,6 +343,7 @@ def main() -> None:
                 current_log = list(chat_log)
                 current_queue = list(message_queue)
                 current_sent = list(sent_messages)
+                current_human = list(messages_to_humans)
             for msg in pending:
                 text = (
                     f"[{msg['timestamp']}] {msg['sender']}: {msg['message']}\n"
@@ -363,7 +365,7 @@ def main() -> None:
                 if listener_counter <= 0:
                     listener_ai = random.choice(active_listeners)
                     msg = current_queue[0]
-                    outputs = [m["message"] for m in current_sent if m["epoch"] >= msg["epoch"]]
+                    outputs = [m["message"] for m in current_human if m["epoch"] >= msg["epoch"]]
                     if listener_ai.check_answered(msg["message"], outputs):
                         with chat_lock:
                             message_queue.pop(0)


### PR DESCRIPTION
## Summary
- add placeholder for messages sent to humans
- allow Listener to provide conversation transcript when prompting other AIs
- ensure listener checks only messages addressed to humans

## Testing
- `python -m py_compile ai_model.py conductor.py fenra_ui.py runtime_utils.py tools.py`

------
https://chatgpt.com/codex/tasks/task_e_6876dfc0cef0832d8fc6d6bbbe6eca6a