### PR TITLE
Improve chatlog handling and queue persistence

### DIFF
--- a/ai_model.py
+++ b/ai_model.py
@@ -387,18 +387,6 @@ class Archivist(Agent):
 
         summary = self.model.generate_from_prompt(prompt, num_ctx=word_count)
 
-        try:
-            with open("summary.txt", "w", encoding="utf-8") as f:
-                f.write(summary)
-        except OSError as exc:
-            self.logger.error("Failed to write summary: %s", exc)
-
-        try:
-            with open("summary_log.txt", "a", encoding="utf-8") as f:
-                f.write(f"[{ts}] {summary}\n{'-' * 80}\n")
-        except OSError as exc:
-            self.logger.error("Failed to update summary log: %s", exc)
-
         self.logger.info("Summary generated")
         self.logger.debug("Exiting Archivist.step")
         return summary


### PR DESCRIPTION
## Summary
- keep live chat logs under `chatlogs` directory
- archive summaries to `chatlogs/summarized`
- persist queued messages in `chatlogs/queued_messages.json`
- drop unused summary text files

## Testing
- `python -m py_compile conductor.py ai_model.py fenra_ui.py runtime_utils.py tools.py`

------
https://chatgpt.com/codex/tasks/task_e_6877ac9dba10832d9bf692e980f9781e