### PR TITLE
Implement Speaker and fix message propagation

### DIFF
--- a/ai_model.py
+++ b/ai_model.py
@@ -472,3 +472,16 @@ class Listener(Agent):
         reply = self.model.generate_from_prompt(prompt, system="")
         return reply
 
+
+class Speaker(Agent):
+    """Agent responsible for communicating with humans."""
+
+    def step(self, context: List[Dict[str, str]]) -> str:
+        """Generate a response intended for the outside world."""
+        self.logger.debug("Entering Speaker.step with context=%s", context)
+        self.logger.info("Generating response")
+        reply = self.model.generate_response(context)
+        self.logger.debug("Response length %d", len(reply))
+        self.logger.debug("Exiting Speaker.step")
+        return reply
+

--- a/conductor.py
+++ b/conductor.py
@@ -14,7 +14,7 @@ import math
 import logging
 import requests
 
-from ai_model import Ruminator, Archivist, ToolAgent, Listener
+from ai_model import Ruminator, Archivist, ToolAgent, Listener, Speaker
 from fenra_ui import FenraUI
 from runtime_utils import init_global_logging, parse_log_level, create_object_logger
 
@@ -129,6 +129,16 @@ def load_config(path: str):
         elif role == "listener":
             agents.append(
                 Listener(
+                    name=section,
+                    model_name=model_id,
+                    role_prompt=role_prompt,
+                    config=cfg,
+                    groups=groups,
+                )
+            )
+        elif role == "speaker":
+            agents.append(
+                Speaker(
                     name=section,
                     model_name=model_id,
                     role_prompt=role_prompt,
@@ -442,7 +452,8 @@ def main() -> None:
                 with chat_lock:
                     chat_log.append(entry)
                     sent_messages.append(entry)
-                    messages_to_humans.append(entry)
+                    if isinstance(ai, Speaker):
+                        messages_to_humans.append(entry)
                 text = f"[{timestamp}] {ai.name}: {reply}\n{'-' * 80}\n\n"
                 for group in ai.groups:
                     fname = os.path.join("chatlogs", f"chat_log_{group}.txt")
@@ -518,7 +529,8 @@ def main() -> None:
                 }
                 chat_log.append(entry)
                 sent_messages.append(entry)
-                messages_to_humans.append(entry)
+                if isinstance(ai, Speaker):
+                    messages_to_humans.append(entry)
             logger.info("%s: generated response", ai.name)
             text = f"[{timestamp}] {ai.name}: {reply}\n{'-' * 80}\n\n"
             print(text)
@@ -584,7 +596,6 @@ def main() -> None:
                         }
                         chat_log.append(entry)
                         sent_messages.append(entry)
-                        messages_to_humans.append(entry)
                     msg_count = 0
 
             time.sleep(0.5)


### PR DESCRIPTION
## Summary
- introduce a `Speaker` agent class
- allow configuration loader to create Speaker instances
- only record world-facing messages when generated by `Speaker`

## Testing
- `python -m py_compile ai_model.py conductor.py runtime_utils.py fenra_ui.py`


------
https://chatgpt.com/codex/tasks/task_e_6877b8710934832db238d57d236b1e74