### PR TITLE
Add Speaker logging and UI display

### DIFF
--- a/ai_model.py
+++ b/ai_model.py
@@ -480,7 +480,18 @@ class Speaker(Agent):
         """Generate a response intended for the outside world."""
         self.logger.debug("Entering Speaker.step with context=%s", context)
         self.logger.info("Generating response")
-        reply = self.model.generate_response(context)
+        prompt = self.model.build_prompt(context)
+        parts = []
+        if self.model.system_prompt:
+            parts.append(self.model.system_prompt)
+        role_topic = " ".join(
+            [p for p in [self.model.role_prompt, self.model.topic_prompt] if p]
+        )
+        if role_topic:
+            parts.append(role_topic)
+        parts.append("You are speaking to humans.")
+        system_text = "\n".join(parts)
+        reply = self.model.generate_from_prompt(prompt, system=system_text)
         self.logger.debug("Response length %d", len(reply))
         self.logger.debug("Exiting Speaker.step")
         return reply

--- a/fenra_ui.py
+++ b/fenra_ui.py
@@ -68,6 +68,10 @@ class FenraUI:
         tk.Label(right, text="Queued Messages:").pack(fill=tk.X)
         self.queue_list = tk.Listbox(right, height=8)
         self.queue_list.pack(fill=tk.BOTH, expand=True)
+
+        tk.Label(right, text="Sent to Humans:").pack(fill=tk.X)
+        self.sent_list = tk.Listbox(right, height=8)
+        self.sent_list.pack(fill=tk.BOTH, expand=True)
         logger.debug("Exiting FenraUI.__init__")
 
     class _InjectDialog(simpledialog.Dialog):
@@ -168,6 +172,14 @@ class FenraUI:
             text = f"[{m['timestamp']}] {m['message']}"
             self.queue_list.insert(tk.END, text)
         logger.debug("Exiting update_queue")
+
+    def update_sent(self, messages):
+        logger.debug("Entering update_sent messages=%s", messages)
+        self.sent_list.delete(0, tk.END)
+        for m in messages:
+            text = f"[{m['timestamp']}] {m['sender']}: {m['message']}"
+            self.sent_list.insert(tk.END, text)
+        logger.debug("Exiting update_sent")
 
     def _expand_all(self):
         logger.debug("Entering _expand_all")


### PR DESCRIPTION
## Summary
- implement Speaker.step to add human system prompt
- persist messages sent to humans
- update UI with sent message list

## Testing
- `python -m py_compile conductor.py ai_model.py fenra_ui.py runtime_utils.py tools.py`
- `pyflakes conductor.py ai_model.py fenra_ui.py runtime_utils.py tools.py`

------
https://chatgpt.com/codex/tasks/task_e_6877c1abaddc832d93f625619c09977c