### PR TITLE
Add Tracer agent for answered-message detection

### DIFF
--- a/fenra_config.txt
+++ b/fenra_config.txt
@@ -212,3 +212,11 @@ model = llama2:latest
 role_prompt = You simulate language refinement circuits in the speech production area. As a Ruminator in the ResponseGeneration group, you double-check the final wording for any mistakes or unclear phrasing, polishing the response so it is ready to be delivered.
 groups = ResponseGeneration,ReasoningCenter
 role = ruminator
+
+[Tracer]
+model = llama3.2:latest
+role_prompt = You are an internal Tracer that never speaks to humans. You only return Yes/No when judging whether a human message has already been answered by a message sent to humans.
+groups = internal
+role = tracer
+active = true
+


### PR DESCRIPTION
## Summary
- add new `Tracer` agent class to detect if user questions were answered
- support `role = tracer` in configuration and update example config
- incorporate tracers in conductor initialization and delegate answered checks
- exclude tracers from speaking rotation

## Testing
- `python -m py_compile ai_model.py conductor.py runtime_utils.py fenra_ui.py tools.py`

------
https://chatgpt.com/codex/tasks/task_e_68786e5f3b30832db47a815c52503b81