### PR TITLE
Add detailed logging for Tracer

### DIFF
--- a/ai_model.py
+++ b/ai_model.py
@@ -360,16 +360,26 @@ class Tracer(Agent):
         )
         text = strip_think_markup(text)
         cleaned = re.sub(r"[^a-zA-Z]", "", text).lower()
+        self.logger.info(
+            "Tracer._judge_pair: raw=%r → cleaned=%r → verdict=%s",
+            text,
+            cleaned,
+            "yes" in cleaned,
+        )
         return "yes" in cleaned
 
     def is_answered(self, user_message: str, outputs: List[str]) -> bool:
         """Return True iff any sent message answers user_message."""
         if not outputs:
             return False
-        for out in outputs:
-            if self._judge_pair(user_message, out):
-                return True
-        return False
+        result = any(self._judge_pair(user_message, out) for out in outputs)
+        self.logger.info(
+            "Tracer.is_answered: user=%r, outputs=%s → %s",
+            user_message,
+            outputs,
+            result,
+        )
+        return result
 
 
 class Ruminator(Agent):

--- a/conductor.py
+++ b/conductor.py
@@ -487,6 +487,12 @@ def main() -> None:
                 ]
                 # Delegate answered check to Tracer if available
                 answered = tracer.is_answered(msg["message"], outputs) if tracer else ai.check_answered(msg["message"], outputs)
+                logger.info(
+                    'Tracer verdict for "%s": outputs=%s → answered=%s',
+                    msg["message"],
+                    outputs,
+                    answered,
+                )
                 if answered:
                     with chat_lock:
                         message_queue.pop(0)
@@ -510,6 +516,9 @@ def main() -> None:
                 with chat_lock:
                     chat_log.append(entry)
                     sent_messages.append(entry)
+                    messages_to_humans.append(entry)
+                    save_messages_to_humans(messages_to_humans)
+                    append_human_log(entry)
                 text = f"[{timestamp}] {ai.name}: {reply}\n{'-' * 80}\n\n"
                 for group in ai.groups:
                     fname = os.path.join("chatlogs", f"chat_log_{group}.txt")


### PR DESCRIPTION
## Summary
- add tracer verdict logging in `conductor`
- log tracer model responses in `_judge_pair`
- log `is_answered` decisions
- record Listener messages in `messages_to_humans`

## Testing
- `python -m py_compile conductor.py ai_model.py`

------
https://chatgpt.com/codex/tasks/task_e_6878b97cb0ec832db06ba59fc0d74e11