### PR TITLE
Improve watchdog timeout handling

### DIFF
--- a/ai_model.py
+++ b/ai_model.py
@@ -518,10 +518,11 @@ class Listener(Agent):
                     payload,
                     CHECK_MODEL_SIZE,
                     WATCHDOG_TRACKER,
-                    base_timeout=self.watchdog_timeout,
+                    base_timeout=self.model.watchdog_timeout,
                 )
-            except requests.Timeout:
-                self.watchdog_timeout *= 1.05
+            except requests.Timeout as exc:
+                self.model.watchdog_timeout *= 1.05
+                logger.error("Listener.check_answered: timed out: %s", exc)
                 continue
             except Exception as exc:  # noqa: BLE001
                 logger.error("Listener.check_answered: judge call failed: %s", exc)

--- a/conductor.py
+++ b/conductor.py
@@ -53,7 +53,7 @@ def load_config(path: str):
         max_tokens_global_str = parser.get("global", "max_tokens", fallback=None)
         max_tokens_global = int(max_tokens_global_str) if max_tokens_global_str else None
         chat_style_global = parser.get("global", "chat_style", fallback=None)
-        watchdog_global = parser.getint("global", "watchdog_timeout", fallback=1000)
+        watchdog_global = parser.getint("global", "watchdog_timeout", fallback=300)
         debug_level_str = parser.get("global", "debug_level", fallback="INFO")
         init_global_logging(parse_log_level(debug_level_str))
     else:
@@ -61,7 +61,7 @@ def load_config(path: str):
         temperature_global = 0.7
         max_tokens_global = None
         chat_style_global = None
-        watchdog_global = 1000
+        watchdog_global = 300
         init_global_logging(logging.INFO)
 
     agents = []
@@ -180,7 +180,7 @@ def load_global_defaults(path: str) -> Dict[str, object]:
             "temperature": sec.getfloat("temperature", fallback=0.7),
             "max_tokens": max_tok_val,
             "chat_style": sec.get("chat_style", fallback=None),
-            "watchdog_timeout": sec.getint("watchdog_timeout", fallback=1000),
+            "watchdog_timeout": sec.getint("watchdog_timeout", fallback=300),
             "system_prompt": sec.get("system_prompt", fallback=None),
         }
         logger.debug("Exiting load_global_defaults")
@@ -191,7 +191,7 @@ def load_global_defaults(path: str) -> Dict[str, object]:
         "temperature": 0.7,
         "max_tokens": None,
         "chat_style": None,
-        "watchdog_timeout": 1000,
+        "watchdog_timeout": 300,
         "system_prompt": None,
     }
     logger.debug("Exiting load_global_defaults")
@@ -469,14 +469,22 @@ def main() -> None:
                         message_queue.pop(0)
                         save_message_queue(message_queue)
                     ui.root.after(0, ui.update_queue, list(message_queue))
-                    reply = ai.clear_ais(msg["message"])
+                    try:
+                        reply = ai.clear_ais(msg["message"])
+                    except requests.Timeout:
+                        logger.error("%s timed out", ai.name)
+                        continue
                 else:
                     lines = [
                         f"[{m['timestamp']}] {m['sender']}: {m['message']}"
                         for m in messages_to_humans
                     ]
                     ruminations = "\n".join(lines)
-                    reply = ai.prompt_ais(ruminations, msg["message"])
+                    try:
+                        reply = ai.prompt_ais(ruminations, msg["message"])
+                    except requests.Timeout:
+                        logger.error("%s timed out", ai.name)
+                        continue
                 entry = {
                     "sender": ai.name,
                     "timestamp": timestamp,


### PR DESCRIPTION
## Summary
- adjust default watchdog timeout to 300s
- allow generate_with_watchdog to accept a base timeout instead of a hard minimum
- increase an AI's timeout by 5% whenever a timeout occurs
- skip over timeouts in the listener flow
- update config loaders to use the 300s default

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_687acd93a3a8832d89a780eaf293a9b8