### PR TITLE
Fix check_answered NameError

### DIFF
--- a/ai_model.py
+++ b/ai_model.py
@@ -515,8 +515,8 @@ class Listener(Agent):
                 },
             }
 
-            yes_tokens = runtime_utils.tokenize_text(CHECK_MODEL, "Yes")
-            no_tokens = runtime_utils.tokenize_text(CHECK_MODEL, "No")
+            yes_tokens = tokenize_text(CHECK_MODEL, "Yes")
+            no_tokens = tokenize_text(CHECK_MODEL, "No")
             if yes_tokens and no_tokens:
                 bias = {str(t): 100 for t in yes_tokens + no_tokens}
                 payload["options"]["logit_bias"] = bias


### PR DESCRIPTION
## Summary
- fix NameError in check_answered by calling `tokenize_text` directly

## Testing
- `python -m py_compile ai_model.py conductor.py runtime_utils.py tools.py fenra_ui.py`

------
https://chatgpt.com/codex/tasks/task_e_687d142ad73c832d80e53d794150121d