### PR TITLE
Fix speaker selection based on archivist groups

### DIFF
--- a/conductor.py
+++ b/conductor.py
@@ -471,10 +471,13 @@ def main() -> None:
                 prev_groups = rum.groups
 
             if active_archivists:
-                a_candidates = [a for a in active_archivists if set(a.groups) & set(prev_groups)]
+                a_candidates = [
+                    a for a in active_archivists if set(a.groups) & set(prev_groups)
+                ]
                 if not a_candidates:
                     a_candidates = active_archivists
                 archivist_ai = random.choice(a_candidates)
+                prev_groups = archivist_ai.groups
             else:
                 archivist_ai = None
 


### PR DESCRIPTION
## Summary
- ensure the speaker is chosen from groups shared with the archivist

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_687d64cbdc1c832d82fd5f25b760ba40