### PR TITLE
Adjust average on timeout

### DIFF
--- a/ai_model.py
+++ b/ai_model.py
@@ -143,7 +143,6 @@ class AIModel:
                 base_timeout=self.watchdog_timeout,
             )
         except requests.Timeout:
-            self.watchdog_timeout *= 1.05
             raise
         result_text = strip_think_markup(result_text)
         self.logger.debug("Generated %d characters", len(result_text))
@@ -221,7 +220,6 @@ class AIModel:
                 base_timeout=self.watchdog_timeout,
             )
         except requests.Timeout:
-            self.watchdog_timeout *= 1.05
             raise
         result_text = strip_think_markup(result_text)
         self.logger.debug("Generated %d characters", len(result_text))
@@ -275,7 +273,6 @@ class AIModel:
                 base_timeout=self.watchdog_timeout,
             )
         except requests.Timeout:
-            self.watchdog_timeout *= 1.05
             raise
         try:
             data = json.loads(result_text)


### PR DESCRIPTION
## Summary
- handle timeouts by updating the global time tracker rather than bumping watchdog timeout
- call the new `record_timeout` helper from the watchdog when a request times out

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688173512c70832d97b35a4b62ea8da1