### PR TITLE
Add ollama cleanup on timeout

### DIFF
--- a/runtime_utils.py
+++ b/runtime_utils.py
@@ -292,6 +292,25 @@ def generate_with_watchdog(
     except requests.Timeout as exc:
         wd_logger.error("Timeout exceeded")
         tracker.record_timeout()
+        try:
+            import subprocess
+
+            subprocess.run(
+                ["taskkill", "/IM", "ollama.exe", "/F"],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                check=False,
+            )
+            subprocess.run(
+                ["ollama", "ps"],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                check=False,
+            )
+        except Exception as cmd_exc:  # noqa: BLE001
+            wd_logger.error(
+                "Failed running timeout cleanup commands: %s", cmd_exc
+            )
         raise exc
     except Exception as exc:  # noqa: BLE001
         wd_logger.error("Exception during generation: %s", exc)


### PR DESCRIPTION
## Summary
- when `generate_with_watchdog` hits a timeout, also kill `ollama.exe` and check `ollama ps`

## Testing
- `python -m py_compile ai_model.py conductor.py fenra_ui.py runtime_utils.py tools.py`

------
https://chatgpt.com/codex/tasks/task_e_688180f7efbc832da421efc7555a8e13