### PR TITLE
Set static timeout and include user message in chain

### DIFF
--- a/ai_model.py
+++ b/ai_model.py
@@ -9,10 +9,8 @@ from tools import tool_schema, tool_descriptions, call_tool
 from runtime_utils import (
     create_object_logger,
     generate_with_watchdog,
-    parse_model_size,
     strip_think_markup,
     tokenize_text,
-    WATCHDOG_TRACKER,
 )
 
 logger = logging.getLogger(__name__)
@@ -30,7 +28,7 @@ class AIModel:
         temperature: float = 0.7,
         max_tokens: Optional[int] = None,
         chat_style: Optional[str] = None,
-        watchdog_timeout: int = 300,
+        watchdog_timeout: int = 900,
         system_prompt: Optional[str] = None,
     ) -> None:
         logger.debug(
@@ -47,7 +45,6 @@ class AIModel:
         )
         self.name = name
         self.model_id = model_id
-        self.model_size = parse_model_size(model_id)
         self.temperature = temperature
         self.max_tokens = max_tokens
         self.watchdog_timeout = watchdog_timeout
@@ -138,8 +135,6 @@ class AIModel:
         try:
             result_text = generate_with_watchdog(
                 payload,
-                self.model_size,
-                WATCHDOG_TRACKER,
                 base_timeout=self.watchdog_timeout,
             )
         except requests.Timeout:
@@ -215,8 +210,6 @@ class AIModel:
         try:
             result_text = generate_with_watchdog(
                 payload,
-                self.model_size,
-                WATCHDOG_TRACKER,
                 base_timeout=self.watchdog_timeout,
             )
         except requests.Timeout:
@@ -268,8 +261,6 @@ class AIModel:
         try:
             result_text = generate_with_watchdog(
                 payload,
-                self.model_size,
-                WATCHDOG_TRACKER,
                 base_timeout=self.watchdog_timeout,
             )
         except requests.Timeout:
@@ -324,7 +315,7 @@ class Agent:
             temperature=float(config.get("temperature", 0.7)),
             max_tokens=max_tok,
             chat_style=config.get("chat_style"),
-            watchdog_timeout=int(config.get("watchdog_timeout", 300)),
+            watchdog_timeout=int(config.get("watchdog_timeout", 900)),
             system_prompt=config.get("system_prompt"),
         )
 

--- a/fenra_ui.py
+++ b/fenra_ui.py
@@ -54,7 +54,7 @@ class FenraUI:
         self.output = scrolledtext.ScrolledText(left, state="disabled", width=80, height=24)
         self.output.pack(fill=tk.BOTH, expand=True)
         self.base_timeout = (
-            agents[0].watchdog_timeout if agents and hasattr(agents[0], "watchdog_timeout") else 300
+            agents[0].watchdog_timeout if agents and hasattr(agents[0], "watchdog_timeout") else 900
         )
         self.timeout_label = tk.Label(left, text=f"Base Timeout: {self.base_timeout}s")
         self.timeout_label.pack(anchor="w")


### PR DESCRIPTION
## Summary
- simplify `generate_with_watchdog` to use a fixed 15 minute timeout
- update AI model default and config fallbacks to 900 seconds
- include human messages in the conversation log so ruminators and others see them
- reflect new base timeout in the UI

## Testing
- `python -m py_compile ai_model.py runtime_utils.py conductor.py fenra_ui.py`

------
https://chatgpt.com/codex/tasks/task_e_688357343d04832d89496299780bccdd