### PR TITLE
Fix logging initialization and flushing

### DIFF
--- a/runtime_utils.py
+++ b/runtime_utils.py
@@ -1,6 +1,7 @@
 import json
 import os
 import re
+import sys
 import threading
 import time
 from collections import deque
@@ -34,10 +35,10 @@ def init_global_logging(level: int) -> None:
     GLOBAL_LOG_LEVEL = level
     os.makedirs("logs", exist_ok=True)
     handlers = [
-        logging.StreamHandler(),
+        logging.StreamHandler(sys.stdout),
         logging.FileHandler(os.path.join("logs", "fenra.log"), mode="a", encoding="utf-8"),
     ]
-    logging.basicConfig(level=level, format=LOG_FORMAT, handlers=handlers)
+    logging.basicConfig(level=level, format=LOG_FORMAT, handlers=handlers, force=True)
     logger.debug("Exiting init_global_logging")
 
 


### PR DESCRIPTION
## Summary
- initialize global logging at start of `main`
- ensure log handlers flush before exiting
- direct stream handler to stdout and force configuration

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688427e56690832d82c9d50a8dd4c381