### PR TITLE
Fix logger setup and flush

### DIFF
--- a/runtime_utils.py
+++ b/runtime_utils.py
@@ -9,6 +9,7 @@ from typing import Dict, Optional, List, Tuple
 import ctypes
 
 import logging
+import sys
 import requests
 
 
@@ -34,10 +35,10 @@ def init_global_logging(level: int) -> None:
     GLOBAL_LOG_LEVEL = level
     os.makedirs("logs", exist_ok=True)
     handlers = [
-        logging.StreamHandler(),
+        logging.StreamHandler(sys.stdout),
         logging.FileHandler(os.path.join("logs", "fenra.log"), mode="a", encoding="utf-8"),
     ]
-    logging.basicConfig(level=level, format=LOG_FORMAT, handlers=handlers)
+    logging.basicConfig(level=level, format=LOG_FORMAT, handlers=handlers, force=True)
     logger.debug("Exiting init_global_logging")
 
 


### PR DESCRIPTION
## Summary
- parse debug level before logging
- set up logging on stdout with `force=True`
- flush logs before exiting if model pull fails

## Testing
- `python -m py_compile conductor.py runtime_utils.py ai_model.py fenra_ui.py tools.py`

------
https://chatgpt.com/codex/tasks/task_e_688427e56690832d82c9d50a8dd4c381