### PR TITLE
Load ruminators last

### DIFF
--- a/conductor.py
+++ b/conductor.py
@@ -584,7 +584,14 @@ def main() -> None:
 
     def loader() -> None:
         nonlocal all_groups
+        early: List[Agent] = []
+        late: List[Agent] = []
         for agent in iter_load_config(config_path):
+            if isinstance(agent, Ruminator):
+                late.append(agent)
+            else:
+                early.append(agent)
+        for agent in early + late:
             with agent_lock:
                 agents.append(agent)
                 if isinstance(agent, Archivist):


### PR DESCRIPTION
## Summary
- adjust loader order so speakers/listeners/archivists are created before ruminators

## Testing
- `python -m py_compile conductor.py`

------
https://chatgpt.com/codex/tasks/task_e_68842d1e32c0832d92142ab22a4f8891