### PR TITLE
Add queue reload and agent ratio settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ fc.txt
 fenra_config-Fenra.txt
 fenra_config-big.txt
 fenra_config_trunc.txt
+fenra_config-.txt

--- a/ai_model.py
+++ b/ai_model.py
@@ -4,13 +4,13 @@ import re
 import requests
 from typing import List, Dict, Optional
 
-from tools import tool_schema, tool_descriptions, call_tool
+from tools import tool_schema, call_tool
 
 from runtime_utils import (
     create_object_logger,
     generate_with_watchdog,
     strip_think_markup,
-    tokenize_text,
+    WATCHDOG_TRACKER,
 )
 
 logger = logging.getLogger(__name__)

--- a/conductor.py
+++ b/conductor.py
@@ -630,6 +630,15 @@ def step_with_retry(agent: Agent, func: Callable[[], str]) -> str:
 
 
 def main() -> None:
+
+    subprocess.run(
+        ["ollama", "ps"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=False,
+    )
+    
+    time.sleep(10)
     config_path = "fenra_config.txt"
     level = _parse_debug_level(config_path)
     init_global_logging(level)

--- a/fenra_discord.py
+++ b/fenra_discord.py
@@ -41,19 +41,23 @@ class DiscordToFenra(discord.Client):
         if msg.author.bot or msg.channel.id != CHANNEL_ID:
             return
 
-        # build the Fenra‑style queue entry
+        # Use display_name (nickname in that server, or username fallback)
+        author = msg.author.display_name
+
+        # Build a single‐field JSON entry where "message" includes the author
         entry = {
-            "sender": msg.author.name,
             "timestamp": msg.created_at.strftime("%Y-%m-%d %H:%M:%S"),
-            "message": msg.content,
-            # optional: you could add "epoch": msg.created_at.timestamp(),
-            # and/or a "groups": ["general"] key if you like.
+            "message": (
+                f"The following message was sent by Discord user {author}: "
+                f"{msg.content}"
+            )
         }
 
         queue = load_queue()
         queue.append(entry)
         save_queue(queue)
-        print(f"[Discord→Fenra] Queued message from {entry['sender']} at {entry['timestamp']}")
+        print(f"[Discord→Fenra] Queued message at {entry['timestamp']}")
+
 
 # ─── run ─────────────────────────────────────────────────────────────────────
 if __name__ == "__main__":

--- a/fenra_discord.py
+++ b/fenra_discord.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+import os
+import json
+from datetime import datetime
+import discord
+
+# ─── configuration ────────────────────────────────────────────────────────────
+# your bot token (you said you set fenra_token as a system variable)
+DISCORD_TOKEN = os.getenv("fenra_token")
+# the numeric channel ID for #chat-with-fenra (enable Dev Mode → Copy Channel ID)
+CHANNEL_ID = int(os.getenv("DISCORD_CHANNEL_ID", "0"))
+# where Fenra expects queued messages
+QUEUE_PATH = os.path.join("chatlogs", "queued_messages.json")
+
+if not DISCORD_TOKEN or CHANNEL_ID == 0:
+    raise RuntimeError("set fenra_token and DISCORD_CHANNEL_ID env vars before running")
+
+# ─── helpers ─────────────────────────────────────────────────────────────────
+def load_queue():
+    try:
+        with open(QUEUE_PATH, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except Exception:
+        return []
+
+def save_queue(q):
+    os.makedirs(os.path.dirname(QUEUE_PATH), exist_ok=True)
+    with open(QUEUE_PATH, "w", encoding="utf-8") as f:
+        json.dump(q, f, ensure_ascii=False, indent=2)
+
+# ─── Discord client ─────────────────────────────────────────────────────────
+intents = discord.Intents.default()
+intents.message_content = True  # required to read messages
+
+class DiscordToFenra(discord.Client):
+    async def on_ready(self):
+        print(f"[Discord→Fenra] Logged in as {self.user} (listening on {CHANNEL_ID})")
+
+    async def on_message(self, msg):
+        # ignore bots (including itself) and other channels
+        if msg.author.bot or msg.channel.id != CHANNEL_ID:
+            return
+
+        # build the Fenra‑style queue entry
+        entry = {
+            "sender": msg.author.name,
+            "timestamp": msg.created_at.strftime("%Y-%m-%d %H:%M:%S"),
+            "message": msg.content,
+            # optional: you could add "epoch": msg.created_at.timestamp(),
+            # and/or a "groups": ["general"] key if you like.
+        }
+
+        queue = load_queue()
+        queue.append(entry)
+        save_queue(queue)
+        print(f"[Discord→Fenra] Queued message from {entry['sender']} at {entry['timestamp']}")
+
+# ─── run ─────────────────────────────────────────────────────────────────────
+if __name__ == "__main__":
+    client = DiscordToFenra(intents=intents)
+    client.run(DISCORD_TOKEN)

--- a/runtime_utils.py
+++ b/runtime_utils.py
@@ -330,11 +330,19 @@ def generate_with_watchdog(
                 check=False,
             )
             subprocess.run(
+                ["taskkill", "/IM", "ollama app.exe", "/F"],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                check=False,
+            )
+            subprocess.run(
                 ["ollama", "ps"],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
                 check=False,
             )
+            
+            time.sleep(10)
         except Exception as cmd_exc:  # noqa: BLE001
             wd_logger.error(
                 "Failed running timeout cleanup commands: %s", cmd_exc


### PR DESCRIPTION
## Summary
- reload the message queue on each loop iteration
- add new global config options for background role ratios
- choose ruminators, speakers, and archivists based on configured ratios
- replace console prints with debug logging
- fix imports

## Testing
- `python -m py_compile conductor.py ai_model.py runtime_utils.py fenra_ui.py tools.py`
- `flake8 conductor.py ai_model.py runtime_utils.py fenra_ui.py tools.py` *(fails: E501, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_688906a71b7c832db01edd329c711dd4