### PR TITLE
Restart ollama server on timeout

### DIFF
--- a/runtime_utils.py
+++ b/runtime_utils.py
@@ -319,34 +319,6 @@ def generate_with_watchdog(
         return str(text)
     except requests.Timeout as exc:
         wd_logger.error("Timeout exceeded")
-        # Increase the global timeout tracking if applicable
-        try:
-            import subprocess
-
-            subprocess.run(
-                ["taskkill", "/IM", "ollama.exe", "/F"],
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
-                check=False,
-            )
-            subprocess.run(
-                ["taskkill", "/IM", "ollama app.exe", "/F"],
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
-                check=False,
-            )
-            subprocess.run(
-                ["ollama", "ps"],
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
-                check=False,
-            )
-            
-            time.sleep(10)
-        except Exception as cmd_exc:  # noqa: BLE001
-            wd_logger.error(
-                "Failed running timeout cleanup commands: %s", cmd_exc
-            )
         raise exc
     except Exception as exc:  # noqa: BLE001
         wd_logger.error("Exception during generation: %s", exc)


### PR DESCRIPTION
## Summary
- launch the Ollama server from `conductor.py` using `subprocess.Popen`
- keep a module-level `server_proc` and restart it on timeouts
- simplify watchdog code in `runtime_utils.generate_with_watchdog`
- clean up old `taskkill`/`ollama ps` calls

## Testing
- `python -m py_compile conductor.py runtime_utils.py ai_model.py fenra_discord.py fenra_ui.py tools.py`

------
https://chatgpt.com/codex/tasks/task_e_6889f7213b5c832d80cbaa98ec2e1d13