### PR TITLE
Restart ollama process from within conductor

### DIFF
--- a/runtime_utils.py
+++ b/runtime_utils.py
@@ -319,34 +319,6 @@ def generate_with_watchdog(
         return str(text)
     except requests.Timeout as exc:
         wd_logger.error("Timeout exceeded")
-        # Increase the global timeout tracking if applicable
-        try:
-            import subprocess
-
-            subprocess.run(
-                ["taskkill", "/IM", "ollama.exe", "/F"],
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
-                check=False,
-            )
-            subprocess.run(
-                ["taskkill", "/IM", "ollama app.exe", "/F"],
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
-                check=False,
-            )
-            subprocess.run(
-                ["ollama", "ps"],
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
-                check=False,
-            )
-            
-            time.sleep(10)
-        except Exception as cmd_exc:  # noqa: BLE001
-            wd_logger.error(
-                "Failed running timeout cleanup commands: %s", cmd_exc
-            )
         raise exc
     except Exception as exc:  # noqa: BLE001
         wd_logger.error("Exception during generation: %s", exc)


### PR DESCRIPTION
## Summary
- start the Ollama server when `conductor.py` loads using `subprocess.Popen`
- restart the server inside `step_with_retry` on a timeout
- remove leftover restart helper and old server launch in `main`

## Testing
- `python -m py_compile conductor.py runtime_utils.py ai_model.py fenra_discord.py fenra_ui.py tools.py`

------
https://chatgpt.com/codex/tasks/task_e_6889f7213b5c832d80cbaa98ec2e1d13