### PR TITLE
Fix random speaker messages not sent to Discord

### DIFF
--- a/conductor.py
+++ b/conductor.py
@@ -896,6 +896,14 @@ def main() -> None:
                         messages_to_humans.append(entry)
                         save_messages_to_humans(messages_to_humans)
                         append_human_log(entry)
+                        try:
+                            discord_text = (
+                                f"**{entry['sender']}** — {entry['timestamp']}\n"
+                                f"[Internal Reflection]\n{entry['message']}"
+                            )
+                            post_to_discord(discord_text)
+                        except Exception as exc:  # noqa: BLE001
+                            logger.error("Failed to post Speaker message to Discord: %s", exc)
                     text = f"[{timestamp}] {agent.name}: {s_reply}\n{'-' * 80}\n\n"
                     logger.debug(text.strip())
                     for group in agent.groups:


### PR DESCRIPTION
## Summary
- ensure random speaker messages also post to Discord
- mark internal ruminations before sending to Discord

## Testing
- `python -m py_compile conductor.py`
- `python -m py_compile ai_model.py fenra_discord.py fenra_ui.py runtime_utils.py tools.py`
- `flake8 .` *(fails: E501 line too long, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_688a18fe8d5c832da4e3817ae28263da