### PR TITLE
Weighted agent type selection with talkativeness label

### DIFF
--- a/conductor.py
+++ b/conductor.py
@@ -1090,7 +1090,40 @@ def main() -> None:
                     candidates = [b for b in candidates if b is not state_current]
 
                 if candidates:
-                    state_current = random.choice(candidates)
+                    speaker_candidates = [c for c in candidates if isinstance(c, Speaker)]
+                    ruminator_candidates = [
+                        c
+                        for c in candidates
+                        if isinstance(c, Ruminator)
+                        and not isinstance(c, (Ponderer, Doubter))
+                    ]
+                    archivist_candidates = [c for c in candidates if isinstance(c, Archivist)]
+                    ponderer_candidates = [c for c in candidates if isinstance(c, Ponderer)]
+                    doubter_candidates = [c for c in candidates if isinstance(c, Doubter)]
+
+                    pools = []
+                    weights = []
+                    if speaker_candidates:
+                        pools.append(speaker_candidates)
+                        weights.append(talkativeness)
+                    if ruminator_candidates:
+                        pools.append(ruminator_candidates)
+                        weights.append(rumination)
+                    if archivist_candidates:
+                        pools.append(archivist_candidates)
+                        weights.append(forgetfulness)
+                    if ponderer_candidates:
+                        pools.append(ponderer_candidates)
+                        weights.append(boredom)
+                    if doubter_candidates:
+                        pools.append(doubter_candidates)
+                        weights.append(assuredness)
+
+                    if pools:
+                        selected_pool = random.choices(pools, weights=weights, k=1)[0]
+                        state_current = random.choice(selected_pool)
+                    else:
+                        state_current = random.choice(candidates)
                 else:
                     pool = [a for a in active_agents if a is not state_current] or active_agents
                     state_current = random.choice(pool)

--- a/fenra_ui.py
+++ b/fenra_ui.py
@@ -52,7 +52,7 @@ class FenraUI:
 
         values_frame = tk.Frame(values_tab)
         values_frame.pack(fill=tk.X)
-        self.thought_label = tk.Label(values_frame, text="Thoughtfulness: 0.00")
+        self.thought_label = tk.Label(values_frame, text="Talkativeness: 0.00")
         self.thought_label.pack(anchor="w")
         self.rumination_label = tk.Label(values_frame, text="Rumination: 0.00")
         self.rumination_label.pack(anchor="w")
@@ -180,21 +180,21 @@ class FenraUI:
 
     def update_weights(
         self,
-        thoughtfulness: float,
+        talkativeness: float,
         rumination: float,
         forgetfulness: float,
         boredom: float = 0.0,
         assuredness: float = 0.0,
     ) -> None:
         logger.debug(
-            "Entering update_weights thoughtfulness=%s rumination=%s forgetfulness=%s boredom=%s assuredness=%s",
-            thoughtfulness,
+            "Entering update_weights talkativeness=%s rumination=%s forgetfulness=%s boredom=%s assuredness=%s",
+            talkativeness,
             rumination,
             forgetfulness,
             boredom,
             assuredness,
         )
-        self.thought_label.config(text=f"Thoughtfulness: {thoughtfulness:.2f}")
+        self.thought_label.config(text=f"Talkativeness: {talkativeness:.2f}")
         self.rumination_label.config(text=f"Rumination: {rumination:.2f}")
         self.forget_label.config(text=f"Forgetfulness: {forgetfulness:.2f}")
         self.boredom_label.config(text=f"Boredom: {boredom:.2f}")


### PR DESCRIPTION
## Summary
- label talkativeness in UI instead of thoughtfulness
- choose next agent by weighted type when no messages queued

## Testing
- `python -m py_compile conductor.py fenra_ui.py ai_model.py fenra_discord.py runtime_utils.py tools.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ce22e0b20832d9d81225d2358ee20