### PR TITLE
Retry failed agents with backoff and deduplicate Archivist summaries

### DIFF
--- a/ai_model.py
+++ b/ai_model.py
@@ -139,6 +139,7 @@ class AIModel:
             result_text = generate_with_watchdog(
                 payload,
                 base_timeout=self.watchdog_timeout,
+                agent_name=self.name,
             )
         except requests.Timeout:
             raise
@@ -220,6 +221,7 @@ class AIModel:
             result_text = generate_with_watchdog(
                 payload,
                 base_timeout=self.watchdog_timeout,
+                agent_name=self.name,
             )
         except requests.Timeout:
             raise
@@ -273,6 +275,7 @@ class AIModel:
             result_text = generate_with_watchdog(
                 payload,
                 base_timeout=self.watchdog_timeout,
+                agent_name=self.name,
             )
         except requests.Timeout:
             raise
@@ -403,8 +406,8 @@ class Tracer(Agent):
 
         text = generate_with_watchdog(
             payload,
-            self.model.model_size,
-            WATCHDOG_TRACKER,
+            base_timeout=self.model.watchdog_timeout,
+            agent_name=self.name,
         )
         text = strip_think_markup(text)
         cleaned = re.sub(r"[^a-zA-Z]", "", text).lower()


### PR DESCRIPTION
## Summary
- Exponentially retry agent steps on transient errors before rotating, with per-agent backoff and failure caps
- Treat Ollama 5xx responses as transient and log agent names in watchdog requests
- Rotate Archivist logs per group but emit only one consolidated chat entry

## Testing
- `python -m py_compile conductor.py ai_model.py runtime_utils.py fenra_ui.py fenra_discord.py generate_agents.py tools.py`


------
https://chatgpt.com/codex/tasks/task_e_6893981b7000832da340435de85254e6