### PR TITLE
Add agent and group context observability

### DIFF
--- a/conductor.py
+++ b/conductor.py
@@ -48,6 +48,9 @@ def _parse_debug_level(path: str) -> int:
 
 logger = create_object_logger("Conductor")
 
+_ACTIVE_AGENT = threading.local()
+_ACTIVE_AGENT.name = None
+
 
 def _agent_to_ui(agent: Agent) -> dict:
     role = getattr(agent, "role_prompt", "").strip().lower()
@@ -631,6 +634,15 @@ def main() -> None:
     fenra_ui_logger.setLevel(level)
     ui = FenraUI(agents, inject_callback=None, send_callback=None, config_path=config_path)
 
+    def _ui_json_watcher(payload: Dict) -> None:
+        name = getattr(_ACTIVE_AGENT, "name", None) or payload.get("model") or "Unknown"
+        try:
+            ui.update_agent_payload(str(name), payload)
+        except Exception:  # noqa: BLE001
+            logger.exception("UI watcher failed")
+
+    add_json_watcher(_ui_json_watcher)
+
     agent_lock = threading.Lock()
     ready_event = threading.Event()
 
@@ -672,6 +684,23 @@ def main() -> None:
     message_queue: List[Dict[str, object]] = load_message_queue()
     messages_to_humans: List[Dict[str, object]] = load_messages_to_humans()
     chat_lock = threading.Lock()
+
+    group_contexts: Dict[str, str] = defaultdict(str)
+    for entry in chat_log:
+        text = (
+            f"[{entry['timestamp']}] {entry['sender']}: {entry['message']}\n"
+            f"{'-' * 80}\n\n"
+        )
+        for grp in entry.get("groups", ["general"]):
+            group_contexts[grp] += text
+
+    ordered_contexts: Dict[str, str] = {}
+    for g in all_groups:
+        ordered_contexts[g] = group_contexts.get(g, "")
+    for g, txt in group_contexts.items():
+        if g not in ordered_contexts:
+            ordered_contexts[g] = txt
+    ui.set_group_contexts(ordered_contexts)
 
     def conversation_loop() -> None:
         nonlocal talkativeness, forgetfulness, rumination, boredom, certainty
@@ -740,148 +769,162 @@ def main() -> None:
             """Execute ``agent`` one step and update logs/PTCD."""
             nonlocal epoch, talkativeness, rumination, forgetfulness, boredom, certainty
 
-            timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-            with chat_lock:
-                context = [
-                    m
-                    for m in chat_log
-                    if set(m.get("groups", ["general"])) & set(agent.groups_in)
-                ]
-
-            if isinstance(agent, Ponderer):
-                context.append(
-                    {
-                        "sender": "System",
-                        "timestamp": "",
-                        "message": (
-                            "Instruction: Talk about anything except what was said above. "
-                            "Do not self-reference this instruction. Just bring up a new topic naturally."
-                        ),
-                        "groups": list(agent.groups_in),
-                    }
-                )
-            elif isinstance(agent, Doubter):
-                context.append(
-                    {
-                        "sender": "System",
-                        "timestamp": "",
-                        "message": (
-                            "Instruction: Argue against everything that was said above. "
-                            "Do not self-reference this instruction. Just debate against what has been said."
-                        ),
-                        "groups": list(agent.groups_in),
-                    }
-                )
+            _ACTIVE_AGENT.name = agent.name
+            ui.set_active_agent(agent.name)
             try:
-                if ui and hasattr(ui, "update_topology"):
-                    active = _agent_to_ui(agent)
-                    roster = [_agent_to_ui(a) for a in list(active_agents) or agents]
-                    ui.update_topology(active, roster)
-            except Exception:  # noqa: BLE001
-                logger.exception("update_topology failed (non-fatal)")
-            try:
-                agent.model.watchdog_timeout = timeout_secs[agent.name]
-                reply = step_with_retry(agent, lambda: agent.step(context))
-            except Exception as exc:  # noqa: BLE001
-                name = agent.name
-                timeout_secs[name] *= 1.1
-                delay = 2.0
-                logger.error(
-                    "Error from %s: %s — retrying same agent after %.1fs (timeout %.1fs)",
-                    name,
-                    exc,
-                    delay,
-                    timeout_secs[name],
-                )
-                time.sleep(delay)
-                return
-            else:
-                timeout_secs[agent.name] = 900.0
-                agent.model.watchdog_timeout = 900.0
-
-            epoch += 1
-            groups_target = list(agent.groups_out or agent.groups_in or ["general"])
-            if isinstance(agent, Archivist):
-                summary_dir = os.path.join("chatlogs", "summarized")
-                os.makedirs(summary_dir, exist_ok=True)
-
+                timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
                 with chat_lock:
-                    chat_log[:] = [
-                        e
-                        for e in chat_log
-                        if not (set(e.get("groups", ["general"])) & set(groups_target))
+                    context = [
+                        m
+                        for m in chat_log
+                        if set(m.get("groups", ["general"])) & set(agent.groups_in)
                     ]
 
-                text = f"[{timestamp}] {agent.name}: {reply}\n{'-' * 80}\n\n"
-                for group in groups_target:
-                    src = os.path.join("chatlogs", f"chat_log_{group}.txt")
-                    if os.path.exists(src):
-                        dest = os.path.join(
-                            summary_dir,
-                            f"chat_log_{group}_{timestamp.replace(' ', '_').replace(':', '-')}.txt",
-                        )
-                        try:
-                            shutil.move(src, dest)
-                        except Exception as exc:  # noqa: BLE001
-                            logger.error("Failed to move %s to %s: %s", src, dest, exc)
-                    with open(src, "w", encoding="utf-8") as log_file:
-                        log_file.write(text)
+                if isinstance(agent, Ponderer):
+                    context.append(
+                        {
+                            "sender": "System",
+                            "timestamp": "",
+                            "message": (
+                                "Instruction: Talk about anything except what was said above. "
+                                "Do not self-reference this instruction. Just bring up a new topic naturally."
+                            ),
+                            "groups": list(agent.groups_in),
+                        }
+                    )
+                elif isinstance(agent, Doubter):
+                    context.append(
+                        {
+                            "sender": "System",
+                            "timestamp": "",
+                            "message": (
+                                "Instruction: Argue against everything that was said above. "
+                                "Do not self-reference this instruction. Just debate against what has been said."
+                            ),
+                            "groups": list(agent.groups_in),
+                        }
+                    )
+                try:
+                    if ui and hasattr(ui, "update_topology"):
+                        active = _agent_to_ui(agent)
+                        roster = [_agent_to_ui(a) for a in list(active_agents) or agents]
+                        ui.update_topology(active, roster)
+                except Exception:  # noqa: BLE001
+                    logger.exception("update_topology failed (non-fatal)")
 
-                entry = {
-                    "sender": agent.name,
-                    "timestamp": timestamp,
-                    "message": reply,
-                    "groups": groups_target,
-                    "epoch": epoch,
-                }
-                with chat_lock:
-                    chat_log.append(entry)
-                ui.root.after(0, ui.log, entry)
-            else:
-                entry = {
-                    "sender": agent.name,
-                    "timestamp": timestamp,
-                    "message": reply,
-                    "groups": groups_target,
-                    "epoch": epoch,
-                }
-                with chat_lock:
-                    chat_log.append(entry)
-                text = f"[{timestamp}] {agent.name}: {reply}\n{'-' * 80}\n\n"
-                for group in groups_target:
-                    fname = os.path.join("chatlogs", f"chat_log_{group}.txt")
-                    os.makedirs(os.path.dirname(fname), exist_ok=True)
-                    with open(fname, "a", encoding="utf-8") as log_file:
-                        log_file.write(text)
-                logger.debug(text.strip())
-                ui.root.after(0, ui.log, entry)
-                if isinstance(agent, Speaker):
-                    messages_to_humans.append(entry)
-                    save_messages_to_humans(messages_to_humans)
-                    append_human_log(entry)
-                    try:
-                        post_to_discord(entry["message"])
-                    except Exception as exc:  # noqa: BLE001
-                        logger.error("Failed to post Speaker message to Discord: %s", exc)
-                    ui.root.after(0, ui.update_sent, list(messages_to_humans))
+                try:
+                    agent.model.watchdog_timeout = timeout_secs[agent.name]
+                    reply = step_with_retry(agent, lambda: agent.step(context))
+                except Exception as exc:  # noqa: BLE001
+                    name = agent.name
+                    timeout_secs[name] *= 1.1
+                    delay = 2.0
+                    logger.error(
+                        "Error from %s: %s — retrying same agent after %.1fs (timeout %.1fs)",
+                        name,
+                        exc,
+                        delay,
+                        timeout_secs[name],
+                    )
+                    time.sleep(delay)
+                    return
+                else:
+                    timeout_secs[agent.name] = 900.0
+                    agent.model.watchdog_timeout = 900.0
 
-            talkativeness, rumination, forgetfulness, boredom, certainty = simulate_ptcd(
-                agent, talkativeness, rumination, forgetfulness, boredom, certainty
-            )
-            logger.debug(
-                "Weights updated: talkativeness=%.3f forgetfulness=%.3f",
-                talkativeness,
-                forgetfulness,
-            )
-            ui.root.after(
-                0,
-                ui.update_weights,
-                talkativeness,
-                rumination,
-                forgetfulness,
-                boredom,
-                certainty,
-            )
+                    epoch += 1
+                    groups_target = list(agent.groups_out or agent.groups_in or ["general"])
+                    if isinstance(agent, Archivist):
+                        summary_dir = os.path.join("chatlogs", "summarized")
+                        os.makedirs(summary_dir, exist_ok=True)
+
+                        with chat_lock:
+                            chat_log[:] = [
+                                e
+                                for e in chat_log
+                                if not (set(e.get("groups", ["general"])) & set(groups_target))
+                            ]
+
+                        text = f"[{timestamp}] {agent.name}: {reply}\n{'-' * 80}\n\n"
+                        for group in groups_target:
+                            group_contexts[group] = ""
+                            src = os.path.join("chatlogs", f"chat_log_{group}.txt")
+                            if os.path.exists(src):
+                                dest = os.path.join(
+                                    summary_dir,
+                                    f"chat_log_{group}_{timestamp.replace(' ', '_').replace(':', '-')}.txt",
+                                )
+                                try:
+                                    shutil.move(src, dest)
+                                except Exception as exc:  # noqa: BLE001
+                                    logger.error("Failed to move %s to %s: %s", src, dest, exc)
+                            with open(src, "w", encoding="utf-8") as log_file:
+                                log_file.write(text)
+
+                        entry = {
+                            "sender": agent.name,
+                            "timestamp": timestamp,
+                            "message": reply,
+                            "groups": groups_target,
+                            "epoch": epoch,
+                        }
+                        with chat_lock:
+                            chat_log.append(entry)
+                        ui.root.after(0, ui.log, entry)
+                        for group in groups_target:
+                            group_contexts[group] += text
+                            ui.update_group_context(group, group_contexts[group])
+                    else:
+                        entry = {
+                            "sender": agent.name,
+                            "timestamp": timestamp,
+                            "message": reply,
+                            "groups": groups_target,
+                            "epoch": epoch,
+                        }
+                        with chat_lock:
+                            chat_log.append(entry)
+                        text = f"[{timestamp}] {agent.name}: {reply}\n{'-' * 80}\n\n"
+                        for group in groups_target:
+                            fname = os.path.join("chatlogs", f"chat_log_{group}.txt")
+                            os.makedirs(os.path.dirname(fname), exist_ok=True)
+                            with open(fname, "a", encoding="utf-8") as log_file:
+                                log_file.write(text)
+                        logger.debug(text.strip())
+                        ui.root.after(0, ui.log, entry)
+                        if isinstance(agent, Speaker):
+                            messages_to_humans.append(entry)
+                            save_messages_to_humans(messages_to_humans)
+                            append_human_log(entry)
+                            try:
+                                post_to_discord(entry["message"])
+                            except Exception as exc:  # noqa: BLE001
+                                logger.error("Failed to post Speaker message to Discord: %s", exc)
+                            ui.root.after(0, ui.update_sent, list(messages_to_humans))
+                        for group in groups_target:
+                            group_contexts[group] = group_contexts.get(group, "") + text
+                            ui.update_group_context(group, group_contexts[group])
+
+                    talkativeness, rumination, forgetfulness, boredom, certainty = simulate_ptcd(
+                        agent, talkativeness, rumination, forgetfulness, boredom, certainty
+                    )
+                    logger.debug(
+                        "Weights updated: talkativeness=%.3f forgetfulness=%.3f",
+                        talkativeness,
+                        forgetfulness,
+                    )
+                    ui.root.after(
+                        0,
+                        ui.update_weights,
+                        talkativeness,
+                        rumination,
+                        forgetfulness,
+                        boredom,
+                        certainty,
+                    )
+            finally:
+                _ACTIVE_AGENT.name = None
+                ui.set_active_agent("")
 
         def plan_chain(human_groups: List[str]) -> List[Agent]:
             """Plan a chain of agents in response to a human message."""
@@ -1020,6 +1063,9 @@ def main() -> None:
                         log_file.write(text)
                 logger.debug(text.strip())
                 ui.root.after(0, ui.log, entry)
+                for group in groups:
+                    group_contexts[group] = group_contexts.get(group, "") + text
+                    ui.update_group_context(group, group_contexts[group])
 
             if message_queue:
                 with chat_lock:
@@ -1057,6 +1103,9 @@ def main() -> None:
                         log_file.write(text)
                 logger.debug(text.strip())
                 ui.root.after(0, ui.log, human_entry)
+                for group in human_entry["groups"]:
+                    group_contexts[group] = group_contexts.get(group, "") + text
+                    ui.update_group_context(group, group_contexts[group])
 
                 chain = plan_chain(human_entry["groups"])
                 if chain:

--- a/fenra_ui.py
+++ b/fenra_ui.py
@@ -5,7 +5,7 @@ import threading
 import time
 from typing import Optional
 import tkinter as tk
-from tkinter import scrolledtext, simpledialog
+from tkinter import scrolledtext, simpledialog, filedialog
 from tkinter import ttk
 import configparser
 
@@ -44,6 +44,9 @@ class FenraUI:
 
         self.sent_messages = []
         self.log_messages = []
+        self._agent_payloads: dict[str, str] = {}
+        self._active_agent: Optional[str] = None
+        self._group_contexts: dict[str, str] = {}
 
         parser = configparser.ConfigParser()
         try:
@@ -176,6 +179,49 @@ class FenraUI:
         self._topology_agents = []
         self._topology_node_items = {}
         self._topology_tooltip = None
+
+        # ----- Agent Context Tab -----
+        agent_tab = ttk.Frame(self.notebook)
+        self.notebook.add(agent_tab, text="Agent Context")
+
+        self.agent_header = ttk.Label(agent_tab, text="Current Agent: None")
+        self.agent_header.pack(anchor="w", padx=4, pady=2)
+
+        agent_toolbar = ttk.Frame(agent_tab)
+        agent_toolbar.pack(anchor="w", padx=4, pady=2)
+        ttk.Button(agent_toolbar, text="Copy JSON", command=self._copy_agent_payload).pack(
+            side=tk.LEFT, padx=2
+        )
+        ttk.Button(agent_toolbar, text="Save…", command=self._save_agent_payload).pack(
+            side=tk.LEFT, padx=2
+        )
+        ttk.Button(agent_toolbar, text="Clear", command=self._clear_agent_payload).pack(
+            side=tk.LEFT, padx=2
+        )
+
+        self.agent_payload_view = scrolledtext.ScrolledText(
+            agent_tab, state="disabled"
+        )
+        self.agent_payload_view.pack(fill=tk.BOTH, expand=True, padx=4, pady=(0, 4))
+
+        # ----- Group Context Tab -----
+        group_tab = ttk.Frame(self.notebook)
+        self.notebook.add(group_tab, text="Group Context")
+
+        group_paned = ttk.Panedwindow(group_tab, orient=tk.HORIZONTAL)
+        group_paned.pack(fill=tk.BOTH, expand=True)
+
+        list_frame = ttk.Frame(group_paned)
+        text_frame = ttk.Frame(group_paned)
+        group_paned.add(list_frame, weight=1)
+        group_paned.add(text_frame, weight=3)
+
+        self.group_list = tk.Listbox(list_frame, exportselection=False)
+        self.group_list.pack(fill=tk.BOTH, expand=True)
+        self.group_list.bind("<<ListboxSelect>>", self._on_group_select)
+
+        self.group_text = scrolledtext.ScrolledText(text_frame, state="disabled")
+        self.group_text.pack(fill=tk.BOTH, expand=True)
 
         logger.debug(
             "Seeding UI with config weights: talkativeness=%s, rumination=%s, "
@@ -441,6 +487,138 @@ class FenraUI:
 
         self._threadsafe(_open)
         logger.debug("Exiting open_config_editor_dialog")
+
+    def set_active_agent(self, name: str) -> None:
+        logger.debug("Entering set_active_agent name=%s", name)
+
+        def _update():
+            self._active_agent = name or None
+            display = name or "None"
+            self.agent_header.config(text=f"Current Agent: {display}")
+            payload = self._agent_payloads.get(name) if name else ""
+            self._render_agent_payload(payload)
+
+        self._threadsafe(_update)
+        logger.debug("Exiting set_active_agent")
+
+    def update_agent_payload(self, agent: str, payload: dict) -> None:
+        logger.debug(
+            "Entering update_agent_payload agent=%s keys=%s",
+            agent,
+            list(payload.keys()),
+        )
+        text = json.dumps(payload, indent=2, ensure_ascii=False)
+        self._agent_payloads[agent] = text
+
+        def _update():
+            if self._active_agent == agent:
+                self._render_agent_payload(text)
+
+        self._threadsafe(_update)
+        logger.debug("Exiting update_agent_payload")
+
+    def set_group_contexts(self, context_by_group: dict[str, str]) -> None:
+        logger.debug(
+            "Entering set_group_contexts context_by_group_keys=%s",
+            list(context_by_group.keys()),
+        )
+
+        def _update():
+            current = None
+            sel = self.group_list.curselection()
+            if sel:
+                current = self.group_list.get(sel[0])
+            self._group_contexts = dict(context_by_group)
+            self.group_list.delete(0, tk.END)
+            for grp in self._group_contexts:
+                self.group_list.insert(tk.END, grp)
+            target = current if current in self._group_contexts else None
+            if not target and self._group_contexts:
+                target = next(iter(self._group_contexts))
+                idx = list(self._group_contexts).index(target)
+                self.group_list.selection_set(idx)
+            if target:
+                self._render_group_text(self._group_contexts.get(target, ""))
+            else:
+                self._render_group_text("")
+
+        self._threadsafe(_update)
+        logger.debug("Exiting set_group_contexts")
+
+    def update_group_context(self, group: str, text: str) -> None:
+        logger.debug("Entering update_group_context group=%s", group)
+
+        def _update():
+            self._group_contexts[group] = text
+            names = list(self.group_list.get(0, tk.END))
+            if group not in names:
+                self.group_list.insert(tk.END, group)
+            sel = self.group_list.curselection()
+            if sel and self.group_list.get(sel[0]) == group:
+                self._render_group_text(text)
+
+        self._threadsafe(_update)
+        logger.debug("Exiting update_group_context")
+
+    def _on_group_select(self, _event=None):
+        sel = self.group_list.curselection()
+        if not sel:
+            return
+        group = self.group_list.get(sel[0])
+        text = self._group_contexts.get(group, "")
+        self._render_group_text(text)
+
+    def _render_agent_payload(self, text: str | None) -> None:
+        self.agent_payload_view.configure(state="normal")
+        self.agent_payload_view.delete("1.0", tk.END)
+        if text:
+            self.agent_payload_view.insert(tk.END, text)
+            lines = self.agent_payload_view.get("1.0", tk.END).splitlines()
+            if len(lines) > 2000:
+                trimmed = "\n".join(lines[-2000:])
+                self.agent_payload_view.delete("1.0", tk.END)
+                self.agent_payload_view.insert(tk.END, trimmed)
+        self.agent_payload_view.configure(state="disabled")
+        self.agent_payload_view.see(tk.END)
+
+    def _render_group_text(self, text: str) -> None:
+        self.group_text.configure(state="normal")
+        self.group_text.delete("1.0", tk.END)
+        if text:
+            self.group_text.insert(tk.END, text)
+        self.group_text.configure(state="disabled")
+        self.group_text.see(tk.END)
+
+    def _copy_agent_payload(self) -> None:
+        logger.debug("Entering _copy_agent_payload")
+        text = self.agent_payload_view.get("1.0", tk.END).strip()
+        if text:
+            self.root.clipboard_clear()
+            self.root.clipboard_append(text)
+        logger.debug("Exiting _copy_agent_payload")
+
+    def _save_agent_payload(self) -> None:
+        logger.debug("Entering _save_agent_payload")
+        text = self.agent_payload_view.get("1.0", tk.END)
+        if not text.strip():
+            logger.debug("_save_agent_payload called with empty text")
+            return
+        fname = filedialog.asksaveasfilename(
+            defaultextension=".json",
+            filetypes=[("JSON Files", "*.json"), ("All Files", "*.*")],
+        )
+        if fname:
+            try:
+                with open(fname, "w", encoding="utf-8") as f:
+                    f.write(text)
+            except OSError as exc:  # noqa: BLE001
+                logger.error("Failed to save JSON payload: %s", exc)
+        logger.debug("Exiting _save_agent_payload")
+
+    def _clear_agent_payload(self) -> None:
+        logger.debug("Entering _clear_agent_payload")
+        self._render_agent_payload("")
+        logger.debug("Exiting _clear_agent_payload")
 
     def update_topology(self, active_agent: dict, agents: list[dict]) -> None:
         logger.debug("Entering update_topology active_agent=%s agents=%s", active_agent, agents)


### PR DESCRIPTION
## Summary
- Show active agent and last Ollama payload in new **Agent Context** tab with copy/save/clear utilities.
- Browse per-group conversation history in new **Group Context** tab and update contexts live.
- Conductor tracks current agent and forwards payloads via JSON watcher; group contexts update as logs change.

## Testing
- `python -m py_compile fenra_ui.py conductor.py`


------
https://chatgpt.com/codex/tasks/task_e_68a77473af08832dbe1e977d54af7bc7