### PR TITLE
Add optional Fenra UI to conductor

### DIFF
--- a/conductor.py
+++ b/conductor.py
@@ -302,14 +302,18 @@ def _append_human_log(entry: Dict[str, object], path: str = os.path.join("chatlo
 def _read_group_contexts() -> Dict[str, str]:
     ctxs: Dict[str, str] = {}
     os.makedirs("chatlogs", exist_ok=True)
+    seen_groups = set()
     for a in AGENTS:
-        for g in set((a.get("groups_in") or []) + (a.get("groups_out") or [])):
-            path = os.path.join("chatlogs", f"chat_log_{g}.txt")
-            try:
-                with open(path, "r", encoding="utf-8") as f:
-                    ctxs[g] = f.read()
-            except Exception:
-                ctxs[g] = ""
+        for g in (a.get("groups_in") or []) + (a.get("groups_out") or []):
+            if g:
+                seen_groups.add(g)
+    for g in sorted(seen_groups):
+        path = os.path.join("chatlogs", f"chat_log_{g}.txt")
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                ctxs[g] = f.read()
+        except Exception:
+            ctxs[g] = ""
     return ctxs
 
 
@@ -415,6 +419,22 @@ def step_agent(agent_name: str) -> Optional[str]:
         GLOBALS.get("max_context_tokens", 8192),
     )
     prompt = "\n".join(filter(None, [pre, msg, post]))
+    if UI is not None:
+        try:
+            UI.set_active_agent(agent["name"])
+            UI.update_agent_payload(
+                agent["name"],
+                {
+                    "model": model_id,
+                    "temperature": temp,
+                    "system_text": system_text,
+                    "pre_text": pre,
+                    "post_text": post,
+                    "message_preview": (msg or "")[-2000:],
+                },
+            )
+        except Exception:
+            logger.exception("UI payload pre-gen update failed")
     reply = MODEL.generate_from_prompt(
         prompt,
         override_model=model_id,
@@ -475,8 +495,8 @@ def step_agent(agent_name: str) -> Optional[str]:
         json.dump({"used": used, "limit": GLOBALS.get("max_context_tokens", 8192)}, f)
     if UI is not None:
         try:
-            UI.set_active_agent(agent["name"])
-            UI.update_topology(agent, AGENTS)
+            UI.log({"timestamp": timestamp, "sender": agent["name"], "message": reply})
+            full_prompt = "\n".join(filter(None, [system_text, pre, CONTEXT, post]))
             UI.update_agent_payload(
                 agent["name"],
                 {
@@ -485,12 +505,12 @@ def step_agent(agent_name: str) -> Optional[str]:
                     "system_text": system_text,
                     "pre_text": pre,
                     "post_text": post,
-                    "prompt_preview": prompt[-4000:],
+                    "prompt_tail": full_prompt[-4000:],
                 },
             )
             UI.set_group_contexts(_read_group_contexts())
         except Exception:
-            logger.exception("Failed to push UI updates")
+            logger.exception("UI post-gen update failed")
     if used > GLOBALS.get("max_context_tokens", 8192):
         arch_cand = find_archivist_downstream(agent)
         if arch_cand:
@@ -508,8 +528,9 @@ def run_loop(steps: Optional[int] = None) -> None:
             try:
                 UI.set_active_agent(cur)
                 UI.update_topology(AGENTS_BY_NAME[cur], AGENTS)
+                UI.set_group_contexts(_read_group_contexts())
             except Exception:
-                logger.exception("UI update failed (pre-step)")
+                logger.exception("UI pre-step update failed")
         logger.info("Running agent %s", cur)
         nxt = step_agent(cur)
         logger.info("Next agent: %s", nxt)
@@ -559,9 +580,11 @@ if __name__ == "__main__":
         t.start()
         try:
             UI = FenraUI(agents=AGENTS)
-            UI.update_topology(AGENTS_BY_NAME.get(STATE.get("current_agent")), AGENTS)
+            cur = STATE.get("current_agent")
+            if isinstance(cur, str) and cur in AGENTS_BY_NAME:
+                UI.set_active_agent(cur)
+                UI.update_topology(AGENTS_BY_NAME[cur], AGENTS)
             UI.set_group_contexts(_read_group_contexts())
-            UI.set_active_agent(STATE.get("current_agent"))
             UI.start()
         finally:
             UI = None

--- a/conductor.py
+++ b/conductor.py
@@ -4,10 +4,12 @@ import time
 import random
 import shutil
 import argparse
+import threading
 from datetime import datetime
 from typing import Dict, List, Optional, Iterable
 
 import requests
+from fenra_ui import FenraUI
 
 from ai_model import AIModel
 from config_loader import (
@@ -46,6 +48,8 @@ AGENTS_BY_NAME: Dict[str, dict] = {}
 AGENTS_BY_GROUP_IN: Dict[str, set] = {}
 STATE: Dict[str, object] = {}
 CONTEXT: str = ""
+
+UI: Optional[FenraUI] = None
 
 
 def load_all_configs() -> None:
@@ -295,6 +299,20 @@ def _append_human_log(entry: Dict[str, object], path: str = os.path.join("chatlo
         f.write(line)
 
 
+def _read_group_contexts() -> Dict[str, str]:
+    ctxs: Dict[str, str] = {}
+    os.makedirs("chatlogs", exist_ok=True)
+    for a in AGENTS:
+        for g in set((a.get("groups_in") or []) + (a.get("groups_out") or [])):
+            path = os.path.join("chatlogs", f"chat_log_{g}.txt")
+            try:
+                with open(path, "r", encoding="utf-8") as f:
+                    ctxs[g] = f.read()
+            except Exception:
+                ctxs[g] = ""
+    return ctxs
+
+
 def find_archivist_downstream(agent: dict) -> Optional[dict]:
     for cand in downstream_candidates(agent["name"]):
         if CLASSES[cand["agent_class"]].get("is_archivist"):
@@ -455,6 +473,24 @@ def step_agent(agent_name: str) -> Optional[str]:
         used = len((full_prompt or "").split())
     with open(os.path.join("chatlogs", "token_usage.json"), "w", encoding="utf-8") as f:
         json.dump({"used": used, "limit": GLOBALS.get("max_context_tokens", 8192)}, f)
+    if UI is not None:
+        try:
+            UI.set_active_agent(agent["name"])
+            UI.update_topology(agent, AGENTS)
+            UI.update_agent_payload(
+                agent["name"],
+                {
+                    "model": model_id,
+                    "temperature": temp,
+                    "system_text": system_text,
+                    "pre_text": pre,
+                    "post_text": post,
+                    "prompt_preview": prompt[-4000:],
+                },
+            )
+            UI.set_group_contexts(_read_group_contexts())
+        except Exception:
+            logger.exception("Failed to push UI updates")
     if used > GLOBALS.get("max_context_tokens", 8192):
         arch_cand = find_archivist_downstream(agent)
         if arch_cand:
@@ -468,6 +504,12 @@ def run_loop(steps: Optional[int] = None) -> None:
     hist: List[str] = [cur]
     count = 0
     while steps is None or count < steps:
+        if UI is not None:
+            try:
+                UI.set_active_agent(cur)
+                UI.update_topology(AGENTS_BY_NAME[cur], AGENTS)
+            except Exception:
+                logger.exception("UI update failed (pre-step)")
         logger.info("Running agent %s", cur)
         nxt = step_agent(cur)
         logger.info("Next agent: %s", nxt)
@@ -502,7 +544,26 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--once", action="store_true", help="Run a single agent step")
     parser.add_argument("--steps", type=int, default=None, help="Run N steps then exit")
+    parser.add_argument("--ui", action="store_true", help="Launch Tk UI")
     args = parser.parse_args()
     setup()
     steps = 1 if args.once else args.steps
-    run_loop(steps)
+    if args.ui:
+        def _loop() -> None:
+            try:
+                run_loop(steps)
+            except Exception:
+                logger.exception("Agent loop crashed")
+
+        t = threading.Thread(target=_loop, daemon=True)
+        t.start()
+        try:
+            UI = FenraUI(agents=AGENTS)
+            UI.update_topology(AGENTS_BY_NAME.get(STATE.get("current_agent")), AGENTS)
+            UI.set_group_contexts(_read_group_contexts())
+            UI.set_active_agent(STATE.get("current_agent"))
+            UI.start()
+        finally:
+            UI = None
+    else:
+        run_loop(steps)

--- a/confs/agent_classes.json
+++ b/confs/agent_classes.json
@@ -1,32 +1,148 @@
 {
   "classes": [
     {
-      "name": "ruminator",
-      "description": "",
-      "triggering_pdv": "rumination",
-      "pdv_adjustments": [ { "name": "rumination", "delta": 0.02 } ],
-      "reads_message_queue": false,
-      "outputs_to_discord": false,
-      "is_archivist": false,
-      "model": null,
-      "temperature": null,
-      "system_prompt": "",
-      "pre_context_message": "",
-      "post_context_message": ""
+      "name": "IsSpeakerIsListenerIsArchivist",
+      "is_speaker": true,
+      "is_listener": true,
+      "is_archivist": true,
+      "triggering_pdv": "PDV_IsSpeakerIsListenerIsArchivist",
+      "reads_message_queue": true,
+      "pdv_adjustments": [
+        { "name": "PDV_IsSpeakerIsListenerIsArchivist", "delta": -0.07 },
+        { "name": "PDV_IsSpeakerIsListenerNotArchivist", "delta": 0.01 },
+        { "name": "PDV_IsSpeakerNotListenerIsArchivist", "delta": 0.01 },
+        { "name": "PDV_IsSpeakerNotListenerNotArchivist", "delta": 0.01 },
+        { "name": "PDV_NotSpeakerIsListenerIsArchivist", "delta": 0.01 },
+        { "name": "PDV_NotSpeakerIsListenerNotArchivist", "delta": 0.01 },
+        { "name": "PDV_NotSpeakerNotListenerIsArchivist", "delta": 0.01 },
+        { "name": "PDV_NotSpeakerNotListenerNotArchivist", "delta": 0.01 }
+      ]
     },
     {
-      "name": "speaker",
-      "description": "",
-      "triggering_pdv": "talkativeness",
-      "pdv_adjustments": [ { "name": "talkativeness", "delta": 0.02 } ],
-      "reads_message_queue": false,
-      "outputs_to_discord": true,
+      "name": "IsSpeakerIsListenerNotArchivist",
+      "is_speaker": true,
+      "is_listener": true,
       "is_archivist": false,
-      "model": null,
-      "temperature": null,
-      "system_prompt": "",
-      "pre_context_message": "",
-      "post_context_message": ""
+      "triggering_pdv": "PDV_IsSpeakerIsListenerNotArchivist",
+      "reads_message_queue": true,
+      "pdv_adjustments": [
+        { "name": "PDV_IsSpeakerIsListenerNotArchivist", "delta": -0.07 },
+        { "name": "PDV_IsSpeakerIsListenerIsArchivist", "delta": 0.01 },
+        { "name": "PDV_IsSpeakerNotListenerIsArchivist", "delta": 0.01 },
+        { "name": "PDV_IsSpeakerNotListenerNotArchivist", "delta": 0.01 },
+        { "name": "PDV_NotSpeakerIsListenerIsArchivist", "delta": 0.01 },
+        { "name": "PDV_NotSpeakerIsListenerNotArchivist", "delta": 0.01 },
+        { "name": "PDV_NotSpeakerNotListenerIsArchivist", "delta": 0.01 },
+        { "name": "PDV_NotSpeakerNotListenerNotArchivist", "delta": 0.01 }
+      ]
+    },
+    {
+      "name": "IsSpeakerNotListenerIsArchivist",
+      "is_speaker": true,
+      "is_listener": false,
+      "is_archivist": true,
+      "triggering_pdv": "PDV_IsSpeakerNotListenerIsArchivist",
+      "reads_message_queue": false,
+      "pdv_adjustments": [
+        { "name": "PDV_IsSpeakerNotListenerIsArchivist", "delta": -0.07 },
+        { "name": "PDV_IsSpeakerIsListenerIsArchivist", "delta": 0.01 },
+        { "name": "PDV_IsSpeakerIsListenerNotArchivist", "delta": 0.01 },
+        { "name": "PDV_IsSpeakerNotListenerNotArchivist", "delta": 0.01 },
+        { "name": "PDV_NotSpeakerIsListenerIsArchivist", "delta": 0.01 },
+        { "name": "PDV_NotSpeakerIsListenerNotArchivist", "delta": 0.01 },
+        { "name": "PDV_NotSpeakerNotListenerIsArchivist", "delta": 0.01 },
+        { "name": "PDV_NotSpeakerNotListenerNotArchivist", "delta": 0.01 }
+      ]
+    },
+    {
+      "name": "IsSpeakerNotListenerNotArchivist",
+      "is_speaker": true,
+      "is_listener": false,
+      "is_archivist": false,
+      "triggering_pdv": "PDV_IsSpeakerNotListenerNotArchivist",
+      "reads_message_queue": false,
+      "pdv_adjustments": [
+        { "name": "PDV_IsSpeakerNotListenerNotArchivist", "delta": -0.07 },
+        { "name": "PDV_IsSpeakerIsListenerIsArchivist", "delta": 0.01 },
+        { "name": "PDV_IsSpeakerIsListenerNotArchivist", "delta": 0.01 },
+        { "name": "PDV_IsSpeakerNotListenerIsArchivist", "delta": 0.01 },
+        { "name": "PDV_NotSpeakerIsListenerIsArchivist", "delta": 0.01 },
+        { "name": "PDV_NotSpeakerIsListenerNotArchivist", "delta": 0.01 },
+        { "name": "PDV_NotSpeakerNotListenerIsArchivist", "delta": 0.01 },
+        { "name": "PDV_NotSpeakerNotListenerNotArchivist", "delta": 0.01 }
+      ]
+    },
+    {
+      "name": "NotSpeakerIsListenerIsArchivist",
+      "is_speaker": false,
+      "is_listener": true,
+      "is_archivist": true,
+      "triggering_pdv": "PDV_NotSpeakerIsListenerIsArchivist",
+      "reads_message_queue": true,
+      "pdv_adjustments": [
+        { "name": "PDV_NotSpeakerIsListenerIsArchivist", "delta": -0.07 },
+        { "name": "PDV_IsSpeakerIsListenerIsArchivist", "delta": 0.01 },
+        { "name": "PDV_IsSpeakerIsListenerNotArchivist", "delta": 0.01 },
+        { "name": "PDV_IsSpeakerNotListenerIsArchivist", "delta": 0.01 },
+        { "name": "PDV_IsSpeakerNotListenerNotArchivist", "delta": 0.01 },
+        { "name": "PDV_NotSpeakerIsListenerNotArchivist", "delta": 0.01 },
+        { "name": "PDV_NotSpeakerNotListenerIsArchivist", "delta": 0.01 },
+        { "name": "PDV_NotSpeakerNotListenerNotArchivist", "delta": 0.01 }
+      ]
+    },
+    {
+      "name": "NotSpeakerIsListenerNotArchivist",
+      "is_speaker": false,
+      "is_listener": true,
+      "is_archivist": false,
+      "triggering_pdv": "PDV_NotSpeakerIsListenerNotArchivist",
+      "reads_message_queue": true,
+      "pdv_adjustments": [
+        { "name": "PDV_NotSpeakerIsListenerNotArchivist", "delta": -0.07 },
+        { "name": "PDV_IsSpeakerIsListenerIsArchivist", "delta": 0.01 },
+        { "name": "PDV_IsSpeakerIsListenerNotArchivist", "delta": 0.01 },
+        { "name": "PDV_IsSpeakerNotListenerIsArchivist", "delta": 0.01 },
+        { "name": "PDV_IsSpeakerNotListenerNotArchivist", "delta": 0.01 },
+        { "name": "PDV_NotSpeakerIsListenerIsArchivist", "delta": 0.01 },
+        { "name": "PDV_NotSpeakerNotListenerIsArchivist", "delta": 0.01 },
+        { "name": "PDV_NotSpeakerNotListenerNotArchivist", "delta": 0.01 }
+      ]
+    },
+    {
+      "name": "NotSpeakerNotListenerIsArchivist",
+      "is_speaker": false,
+      "is_listener": false,
+      "is_archivist": true,
+      "triggering_pdv": "PDV_NotSpeakerNotListenerIsArchivist",
+      "reads_message_queue": false,
+      "pdv_adjustments": [
+        { "name": "PDV_NotSpeakerNotListenerIsArchivist", "delta": -0.07 },
+        { "name": "PDV_IsSpeakerIsListenerIsArchivist", "delta": 0.01 },
+        { "name": "PDV_IsSpeakerIsListenerNotArchivist", "delta": 0.01 },
+        { "name": "PDV_IsSpeakerNotListenerIsArchivist", "delta": 0.01 },
+        { "name": "PDV_IsSpeakerNotListenerNotArchivist", "delta": 0.01 },
+        { "name": "PDV_NotSpeakerIsListenerIsArchivist", "delta": 0.01 },
+        { "name": "PDV_NotSpeakerIsListenerNotArchivist", "delta": 0.01 },
+        { "name": "PDV_NotSpeakerNotListenerNotArchivist", "delta": 0.01 }
+      ]
+    },
+    {
+      "name": "NotSpeakerNotListenerNotArchivist",
+      "is_speaker": false,
+      "is_listener": false,
+      "is_archivist": false,
+      "triggering_pdv": "PDV_NotSpeakerNotListenerNotArchivist",
+      "reads_message_queue": false,
+      "pdv_adjustments": [
+        { "name": "PDV_NotSpeakerNotListenerNotArchivist", "delta": -0.07 },
+        { "name": "PDV_IsSpeakerIsListenerIsArchivist", "delta": 0.01 },
+        { "name": "PDV_IsSpeakerIsListenerNotArchivist", "delta": 0.01 },
+        { "name": "PDV_IsSpeakerNotListenerIsArchivist", "delta": 0.01 },
+        { "name": "PDV_IsSpeakerNotListenerNotArchivist", "delta": 0.01 },
+        { "name": "PDV_NotSpeakerIsListenerIsArchivist", "delta": 0.01 },
+        { "name": "PDV_NotSpeakerIsListenerNotArchivist", "delta": 0.01 },
+        { "name": "PDV_NotSpeakerNotListenerIsArchivist", "delta": 0.01 }
+      ]
     }
   ]
 }

--- a/confs/agents.json
+++ b/confs/agents.json
@@ -1,34 +1,284 @@
 {
   "agents": [
     {
-      "name": "Ava",
-      "description": "",
-      "agent_class": "ruminator",
-      "groups_in": ["Core"],
-      "groups_out": ["Reasoning"],
-      "model": null,
-      "temperature": null,
-      "system_prompt": "",
-      "pre_context_message": "",
-      "post_context_message": "",
-      "created_at": "2025-08-23T00:00:00Z",
-      "flag_no_downstream": false,
-      "missing_out_groups": []
+      "agent_class": "IsSpeakerIsListenerIsArchivist",
+      "created_at": "2025-08-24T10:11:27.457726Z",
+      "groups_in": [
+        "GroupA"
+      ],
+      "groups_out": [
+        "GroupB"
+      ],
+      "name": "IsSpeakerIsListenerIsArchivist-AinBout"
     },
     {
-      "name": "Echo",
-      "description": "",
-      "agent_class": "speaker",
-      "groups_in": ["Reasoning"],
-      "groups_out": ["Core"],
-      "model": null,
-      "temperature": null,
-      "system_prompt": "",
-      "pre_context_message": "",
-      "post_context_message": "",
-      "created_at": "2025-08-24T00:00:00Z",
-      "flag_no_downstream": false,
-      "missing_out_groups": []
+      "agent_class": "IsSpeakerIsListenerIsArchivist",
+      "created_at": "2025-08-24T10:11:27.457726Z",
+      "groups_in": [
+        "GroupB"
+      ],
+      "groups_out": [
+        "GroupA"
+      ],
+      "name": "IsSpeakerIsListenerIsArchivist-BinAout"
+    },
+    {
+      "agent_class": "IsSpeakerIsListenerIsArchivist",
+      "created_at": "2025-08-24T10:11:27.457726Z",
+      "groups_in": [
+        "GroupA",
+        "GroupB"
+      ],
+      "groups_out": [
+        "GroupA",
+        "GroupB"
+      ],
+      "name": "IsSpeakerIsListenerIsArchivist-BothInOut"
+    },
+    {
+      "agent_class": "IsSpeakerIsListenerNotArchivist",
+      "created_at": "2025-08-24T10:11:27.457726Z",
+      "groups_in": [
+        "GroupA"
+      ],
+      "groups_out": [
+        "GroupB"
+      ],
+      "name": "IsSpeakerIsListenerNotArchivist-AinBout"
+    },
+    {
+      "agent_class": "IsSpeakerIsListenerNotArchivist",
+      "created_at": "2025-08-24T10:11:27.457726Z",
+      "groups_in": [
+        "GroupB"
+      ],
+      "groups_out": [
+        "GroupA"
+      ],
+      "name": "IsSpeakerIsListenerNotArchivist-BinAout"
+    },
+    {
+      "agent_class": "IsSpeakerIsListenerNotArchivist",
+      "created_at": "2025-08-24T10:11:27.457726Z",
+      "groups_in": [
+        "GroupA",
+        "GroupB"
+      ],
+      "groups_out": [
+        "GroupA",
+        "GroupB"
+      ],
+      "name": "IsSpeakerIsListenerNotArchivist-BothInOut"
+    },
+    {
+      "agent_class": "IsSpeakerNotListenerIsArchivist",
+      "created_at": "2025-08-24T10:11:27.457726Z",
+      "groups_in": [
+        "GroupA"
+      ],
+      "groups_out": [
+        "GroupB"
+      ],
+      "name": "IsSpeakerNotListenerIsArchivist-AinBout"
+    },
+    {
+      "agent_class": "IsSpeakerNotListenerIsArchivist",
+      "created_at": "2025-08-24T10:11:27.457726Z",
+      "groups_in": [
+        "GroupB"
+      ],
+      "groups_out": [
+        "GroupA"
+      ],
+      "name": "IsSpeakerNotListenerIsArchivist-BinAout"
+    },
+    {
+      "agent_class": "IsSpeakerNotListenerIsArchivist",
+      "created_at": "2025-08-24T10:11:27.457726Z",
+      "groups_in": [
+        "GroupA",
+        "GroupB"
+      ],
+      "groups_out": [
+        "GroupA",
+        "GroupB"
+      ],
+      "name": "IsSpeakerNotListenerIsArchivist-BothInOut"
+    },
+    {
+      "agent_class": "IsSpeakerNotListenerNotArchivist",
+      "created_at": "2025-08-24T10:11:27.457726Z",
+      "groups_in": [
+        "GroupA"
+      ],
+      "groups_out": [
+        "GroupB"
+      ],
+      "name": "IsSpeakerNotListenerNotArchivist-AinBout"
+    },
+    {
+      "agent_class": "IsSpeakerNotListenerNotArchivist",
+      "created_at": "2025-08-24T10:11:27.457726Z",
+      "groups_in": [
+        "GroupB"
+      ],
+      "groups_out": [
+        "GroupA"
+      ],
+      "name": "IsSpeakerNotListenerNotArchivist-BinAout"
+    },
+    {
+      "agent_class": "IsSpeakerNotListenerNotArchivist",
+      "created_at": "2025-08-24T10:11:27.457726Z",
+      "groups_in": [
+        "GroupA",
+        "GroupB"
+      ],
+      "groups_out": [
+        "GroupA",
+        "GroupB"
+      ],
+      "name": "IsSpeakerNotListenerNotArchivist-BothInOut"
+    },
+    {
+      "agent_class": "NotSpeakerIsListenerIsArchivist",
+      "created_at": "2025-08-24T10:11:27.457726Z",
+      "groups_in": [
+        "GroupA"
+      ],
+      "groups_out": [
+        "GroupB"
+      ],
+      "name": "NotSpeakerIsListenerIsArchivist-AinBout"
+    },
+    {
+      "agent_class": "NotSpeakerIsListenerIsArchivist",
+      "created_at": "2025-08-24T10:11:27.457726Z",
+      "groups_in": [
+        "GroupB"
+      ],
+      "groups_out": [
+        "GroupA"
+      ],
+      "name": "NotSpeakerIsListenerIsArchivist-BinAout"
+    },
+    {
+      "agent_class": "NotSpeakerIsListenerIsArchivist",
+      "created_at": "2025-08-24T10:11:27.457726Z",
+      "groups_in": [
+        "GroupA",
+        "GroupB"
+      ],
+      "groups_out": [
+        "GroupA",
+        "GroupB"
+      ],
+      "name": "NotSpeakerIsListenerIsArchivist-BothInOut"
+    },
+    {
+      "agent_class": "NotSpeakerIsListenerNotArchivist",
+      "created_at": "2025-08-24T10:11:27.457726Z",
+      "groups_in": [
+        "GroupA"
+      ],
+      "groups_out": [
+        "GroupB"
+      ],
+      "name": "NotSpeakerIsListenerNotArchivist-AinBout"
+    },
+    {
+      "agent_class": "NotSpeakerIsListenerNotArchivist",
+      "created_at": "2025-08-24T10:11:27.457726Z",
+      "groups_in": [
+        "GroupB"
+      ],
+      "groups_out": [
+        "GroupA"
+      ],
+      "name": "NotSpeakerIsListenerNotArchivist-BinAout"
+    },
+    {
+      "agent_class": "NotSpeakerIsListenerNotArchivist",
+      "created_at": "2025-08-24T10:11:27.457726Z",
+      "groups_in": [
+        "GroupA",
+        "GroupB"
+      ],
+      "groups_out": [
+        "GroupA",
+        "GroupB"
+      ],
+      "name": "NotSpeakerIsListenerNotArchivist-BothInOut"
+    },
+    {
+      "agent_class": "NotSpeakerNotListenerIsArchivist",
+      "created_at": "2025-08-24T10:11:27.457726Z",
+      "groups_in": [
+        "GroupA"
+      ],
+      "groups_out": [
+        "GroupB"
+      ],
+      "name": "NotSpeakerNotListenerIsArchivist-AinBout"
+    },
+    {
+      "agent_class": "NotSpeakerNotListenerIsArchivist",
+      "created_at": "2025-08-24T10:11:27.457726Z",
+      "groups_in": [
+        "GroupB"
+      ],
+      "groups_out": [
+        "GroupA"
+      ],
+      "name": "NotSpeakerNotListenerIsArchivist-BinAout"
+    },
+    {
+      "agent_class": "NotSpeakerNotListenerIsArchivist",
+      "created_at": "2025-08-24T10:11:27.457726Z",
+      "groups_in": [
+        "GroupA",
+        "GroupB"
+      ],
+      "groups_out": [
+        "GroupA",
+        "GroupB"
+      ],
+      "name": "NotSpeakerNotListenerIsArchivist-BothInOut"
+    },
+    {
+      "agent_class": "NotSpeakerNotListenerNotArchivist",
+      "created_at": "2025-08-24T10:11:27.457726Z",
+      "groups_in": [
+        "GroupA"
+      ],
+      "groups_out": [
+        "GroupB"
+      ],
+      "name": "NotSpeakerNotListenerNotArchivist-AinBout"
+    },
+    {
+      "agent_class": "NotSpeakerNotListenerNotArchivist",
+      "created_at": "2025-08-24T10:11:27.457726Z",
+      "groups_in": [
+        "GroupB"
+      ],
+      "groups_out": [
+        "GroupA"
+      ],
+      "name": "NotSpeakerNotListenerNotArchivist-BinAout"
+    },
+    {
+      "agent_class": "NotSpeakerNotListenerNotArchivist",
+      "created_at": "2025-08-24T10:11:27.457726Z",
+      "groups_in": [
+        "GroupA",
+        "GroupB"
+      ],
+      "groups_out": [
+        "GroupA",
+        "GroupB"
+      ],
+      "name": "NotSpeakerNotListenerNotArchivist-BothInOut"
     }
   ]
 }

--- a/confs/globals.json
+++ b/confs/globals.json
@@ -1,6 +1,6 @@
 {
-  "debug_level": "INFO",
-  "model": "llama3:8b",
+  "debug_level": "WARNING",
+  "model": "gpt-oss:20b",
   "temperature": 0.7,
   "system_prompt": "",
   "pre_context_message": "",

--- a/confs/pdvs.json
+++ b/confs/pdvs.json
@@ -1,9 +1,44 @@
 {
   "pdvs": [
-    { "name": "talkativeness", "description": "", "value": 0.5 },
-    { "name": "rumination", "description": "", "value": 0.5 },
-    { "name": "forgetfulness", "description": "", "value": 0.5 },
-    { "name": "boredom", "description": "", "value": 0.5 },
-    { "name": "certainty", "description": "", "value": 0.5 }
+    {
+      "description": "PDV for IsSpeakerIsListenerIsArchivist",
+      "name": "PDV_IsSpeakerIsListenerIsArchivist",
+      "value": 0.4396118416
+    },
+    {
+      "description": "PDV for IsSpeakerIsListenerNotArchivist",
+      "name": "PDV_IsSpeakerIsListenerNotArchivist",
+      "value": 0.5199920016
+    },
+    {
+      "description": "PDV for IsSpeakerNotListenerIsArchivist",
+      "name": "PDV_IsSpeakerNotListenerIsArchivist",
+      "value": 0.5199920016
+    },
+    {
+      "description": "PDV for IsSpeakerNotListenerNotArchivist",
+      "name": "PDV_IsSpeakerNotListenerNotArchivist",
+      "value": 0.5199920016
+    },
+    {
+      "description": "PDV for NotSpeakerIsListenerIsArchivist",
+      "name": "PDV_NotSpeakerIsListenerIsArchivist",
+      "value": 0.5199920016
+    },
+    {
+      "description": "PDV for NotSpeakerIsListenerNotArchivist",
+      "name": "PDV_NotSpeakerIsListenerNotArchivist",
+      "value": 0.44005598879999996
+    },
+    {
+      "description": "PDV for NotSpeakerNotListenerIsArchivist",
+      "name": "PDV_NotSpeakerNotListenerIsArchivist",
+      "value": 0.5199920016
+    },
+    {
+      "description": "PDV for NotSpeakerNotListenerNotArchivist",
+      "name": "PDV_NotSpeakerNotListenerNotArchivist",
+      "value": 0.5199920016
+    }
   ]
 }

--- a/confs/state.json
+++ b/confs/state.json
@@ -1,4 +1,4 @@
 {
-  "current_agent": "Ava",
-  "pdv_history_path": "chatlogs/pdv_history.jsonl"
+  "current_agent": "NotSpeakerNotListenerNotArchivist-BothInOut",
+  "pdv_history_path": "chatlogs\\pdv_history.jsonl"
 }


### PR DESCRIPTION
## Summary
- add optional Tkinter UI via `--ui` flag
- send agent, topology, group context and payload updates to FenraUI
- run agent loop in background when UI active to keep UI responsive

## Testing
- `pytest`
- `python conductor.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68aaddf3fd04832d9572250c0e6d0312