### PR TITLE
Prefer queue listeners when messages pending

### DIFF
--- a/conductor.py
+++ b/conductor.py
@@ -239,9 +239,18 @@ def select_next_agent(curr_name: str) -> Optional[dict]:
         cur = AGENTS_BY_NAME[curr_name]
         _flag_no_downstream(cur, cur.get("groups_out", []))
         return None
-    pdvs = {CLASSES[a["agent_class"]]["triggering_pdv"] for a in D}
+    # If there are queued messages, prefer candidates that can read the queue.
+    C0 = D
+    if has_queued_messages():
+        listener_candidates = [
+            a for a in D if CLASSES[a["agent_class"]].get("reads_message_queue")
+        ]
+        if listener_candidates:
+            C0 = listener_candidates
+    # PDV-trigger selection among the chosen candidate set (listener subset if any; otherwise all downstream)
+    pdvs = {CLASSES[a["agent_class"]]["triggering_pdv"] for a in C0}
     target = max(pdvs, key=lambda p: PDVS.get(p, 0.0))
-    C = [a for a in D if CLASSES[a["agent_class"]]["triggering_pdv"] == target] or D
+    C = [a for a in C0 if CLASSES[a["agent_class"]]["triggering_pdv"] == target] or C0
     random.shuffle(C)
     for cand in C:
         outs = set(cand.get("groups_out", []))
@@ -276,6 +285,18 @@ def merge_and_clear_queue(path: str = QUEUE_PATH) -> str:
         except Exception:
             pass
     return "\n".join(lines)
+
+
+def has_queued_messages(path: str = QUEUE_PATH) -> bool:
+    """Return True if there are pending messages in the Discord/user queue.
+    This MUST NOT mutate or clear the queue. Only listeners drain it inside step_agent().
+    """
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            items = json.load(f) or []
+        return bool(items)
+    except Exception:
+        return False
 
 
 def _load_messages_to_humans(path: str = os.path.join("chatlogs", "messages_to_humans.json")) -> List[Dict[str, object]]:

--- a/tests/test_conductor_selection.py
+++ b/tests/test_conductor_selection.py
@@ -1,3 +1,4 @@
+import json
 import conductor
 
 
@@ -50,3 +51,79 @@ def test_dead_end_flagging():
     assert res is None
     assert solo.get("flag_no_downstream") is True
     assert solo.get("missing_out_groups") == ["G2"]
+
+
+def test_select_next_agent_prefers_listener(tmp_path):
+    conductor.save_agents = lambda *a, **k: None
+    queue_path = tmp_path / "queued_messages.json"
+    conductor.QUEUE_PATH = str(queue_path)
+    queue_path.parent.mkdir(parents=True, exist_ok=True)
+    queue_path.write_text(json.dumps([{"message": "hi"}]))
+    orig_has_queue = conductor.has_queued_messages
+    conductor.has_queued_messages = lambda path=str(queue_path): orig_has_queue(str(queue_path))
+
+    conductor.PDVS = {"talk": 0.5}
+    conductor.CLASSES = {
+        "base": {"triggering_pdv": "talk", "pdv_adjustments": []},
+        "listener": {"triggering_pdv": "talk", "pdv_adjustments": [], "reads_message_queue": True},
+    }
+    src = {"name": "Src", "agent_class": "base", "groups_out": ["G"], "groups_in": []}
+    non_listener = {
+        "name": "NonListener",
+        "agent_class": "base",
+        "groups_in": ["G"],
+        "groups_out": [],
+    }
+    listener = {
+        "name": "Listener",
+        "agent_class": "listener",
+        "groups_in": ["G"],
+        "groups_out": ["Out"],
+    }
+    non_listener["groups_out"] = ["Out"]
+    sink = {
+        "name": "Sink",
+        "agent_class": "base",
+        "groups_in": ["Out"],
+        "groups_out": [],
+    }
+    conductor.AGENTS = [src, non_listener, listener, sink]
+    conductor.AGENTS_BY_NAME = {a["name"]: a for a in conductor.AGENTS}
+    conductor.AGENTS_BY_GROUP_IN = {"G": {"NonListener", "Listener"}, "Out": {"Sink"}}
+
+    nxt = conductor.select_next_agent("Src")
+    assert nxt["name"] == "Listener"
+
+
+def test_select_next_agent_queue_no_listeners(tmp_path):
+    conductor.save_agents = lambda *a, **k: None
+    queue_path = tmp_path / "queued_messages.json"
+    conductor.QUEUE_PATH = str(queue_path)
+    queue_path.parent.mkdir(parents=True, exist_ok=True)
+    queue_path.write_text(json.dumps([{"message": "hi"}]))
+    orig_has_queue = conductor.has_queued_messages
+    conductor.has_queued_messages = lambda path=str(queue_path): orig_has_queue(str(queue_path))
+
+    conductor.PDVS = {"talk": 0.5}
+    conductor.CLASSES = {
+        "base": {"triggering_pdv": "talk", "pdv_adjustments": []},
+    }
+    src = {"name": "Src", "agent_class": "base", "groups_out": ["G"], "groups_in": []}
+    dst = {
+        "name": "Dst",
+        "agent_class": "base",
+        "groups_in": ["G"],
+        "groups_out": ["Out"],
+    }
+    sink = {
+        "name": "Sink",
+        "agent_class": "base",
+        "groups_in": ["Out"],
+        "groups_out": [],
+    }
+    conductor.AGENTS = [src, dst, sink]
+    conductor.AGENTS_BY_NAME = {a["name"]: a for a in conductor.AGENTS}
+    conductor.AGENTS_BY_GROUP_IN = {"G": {"Dst"}, "Out": {"Sink"}}
+
+    nxt = conductor.select_next_agent("Src")
+    assert nxt["name"] == "Dst"


### PR DESCRIPTION
## Summary
- Add `has_queued_messages` helper to check for pending Discord/user messages
- Update agent selection to prioritize listeners when messages are queued
- Cover new behavior with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aba2d1adc0832daf4f7d3172674293