### PR TITLE
feat: support DPVM adjustments on Discord ingestion

### DIFF
--- a/fenra_discord.py
+++ b/fenra_discord.py
@@ -4,6 +4,9 @@ import json
 from datetime import datetime
 import discord
 
+from config_loader import load_globals
+from pdv_utils import apply_and_persist_pdv_adjustments
+
 # ─── configuration ────────────────────────────────────────────────────────────
 # your bot token (you said you set fenra_token as a system variable)
 DISCORD_TOKEN = os.getenv("fenra_token")
@@ -57,6 +60,16 @@ class DiscordToFenra(discord.Client):
         queue.append(entry)
         save_queue(queue)
         print(f"[Discord→Fenra] Queued message at {entry['timestamp']}")
+
+        # After enqueueing, apply any configured DPVMs for incoming messages.
+        try:
+            g = load_globals()
+            adjs = g.get("incoming_message_dpvms") or []
+            if isinstance(adjs, list) and adjs:
+                apply_and_persist_pdv_adjustments(adjs)
+        except Exception as e:
+            # Non-fatal: log-visible but do not crash the client
+            print(f"[Discord→Fenra] DPVM apply failed: {e}")
 
 
 # ─── run ─────────────────────────────────────────────────────────────────────

--- a/pdv_utils.py
+++ b/pdv_utils.py
@@ -1,0 +1,92 @@
+import os
+import time
+import json
+from typing import List, Dict
+
+from config_loader import load_globals, load_pdvs, save_pdvs
+
+
+def _clamp01(x: float) -> float:
+    """Clamp *x* to the range [0.0, 1.0]."""
+    if x < 0.0:
+        return 0.0
+    if x > 1.0:
+        return 1.0
+    return x
+
+
+def _ensure_dirs() -> None:
+    """Ensure output directories for PDV logs exist."""
+    os.makedirs("chatlogs", exist_ok=True)
+
+
+def _pdv_values_map(pdvs_cfg: Dict[str, dict]) -> Dict[str, float]:
+    """Return a map of PDV name -> float value from the config mapping."""
+    return {name: float(cfg.get("value", 0.5)) for name, cfg in pdvs_cfg.items()}
+
+
+def apply_and_persist_pdv_adjustments(adjs: List[dict]) -> Dict[str, float]:
+    """Apply gamma-scaled PDV deltas and persist results.
+
+    Parameters
+    ----------
+    adjs: list of dict
+        Adjustment items describing the PDV name and delta.
+
+    Returns
+    -------
+    dict
+        Mapping of PDV name -> current value after applying adjustments.
+    """
+    globals_cfg = load_globals()
+    try:
+        gamma = float(globals_cfg.get("pdv_gamma", 2.0))
+    except Exception:
+        gamma = 2.0
+
+    pdvs_cfg = load_pdvs()
+    values = _pdv_values_map(pdvs_cfg)
+
+    changed = False
+    for item in adjs or []:
+        name = item.get("name")
+        if not isinstance(name, str) or not name.strip():
+            continue
+
+        delta = None
+        if "delta_pct" in item:
+            try:
+                delta = float(item["delta_pct"]) / 100.0
+            except Exception:
+                continue
+        elif "delta" in item:
+            try:
+                delta = float(item["delta"])
+            except Exception:
+                continue
+        if delta is None:
+            continue
+
+        x = float(values.get(name, 0.5))
+        g = (4.0 * x * (1.0 - x)) ** gamma
+        x2 = _clamp01(x + delta * g)
+
+        if abs(x2 - x) > 1e-12:
+            values[name] = x2
+            if name not in pdvs_cfg:
+                pdvs_cfg[name] = {"name": name, "description": "", "value": x2}
+            else:
+                pdvs_cfg[name]["value"] = x2
+            changed = True
+
+    if changed:
+        save_pdvs(pdvs_cfg)
+        _ensure_dirs()
+        history_path = os.path.join("chatlogs", "pdv_history.jsonl")
+        with open(history_path, "a", encoding="utf-8") as f:
+            f.write(json.dumps({"ts": time.time(), "pdvs": values}, ensure_ascii=False) + "\n")
+        live_path = os.path.join("chatlogs", "pdvs_live.json")
+        with open(live_path, "w", encoding="utf-8") as f:
+            json.dump(values, f)
+
+    return values


### PR DESCRIPTION
## Summary
- add `pdv_utils` helper to apply gamma-scaled PDV adjustments and persist history/live files
- call PDV adjustments in `fenra_discord` when messages arrive

## Testing
- `python -m py_compile pdv_utils.py fenra_discord.py && echo 'py_compile succeeded'`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac32ab3b38832da4c45db80d8af65d