### PR TITLE
Ensure conductor syncs PDVs from disk before updates

### DIFF
--- a/conductor.py
+++ b/conductor.py
@@ -109,6 +109,17 @@ def load_all_configs() -> None:
         save_state(STATE)
 
 
+def _refresh_pdvs_from_disk() -> None:
+    """Synchronize in-memory PDV state with confs/pdvs.json."""
+    global PDV_META, PDVS
+    try:
+        raw_pdvs = load_pdvs()
+    except Exception:
+        return
+    PDV_META = dict(raw_pdvs)
+    PDVS = {name: cfg.get("value", 0.5) for name, cfg in raw_pdvs.items()}
+
+
 def effective_params(agent: dict):
     cls = CLASSES[agent["agent_class"]]
     model = agent.get("model") or cls.get("model") or GLOBALS.get("model")
@@ -191,6 +202,8 @@ def post_to_discord_via_webhook(content: str) -> None:
 # ----------------------------------------------------------------------------
 
 def apply_pdv_adjustments(adjs: List[dict]) -> None:
+    # Ensure we never apply deltas on stale values.
+    _refresh_pdvs_from_disk()
     gamma = float(GLOBALS.get("pdv_gamma", 2.0))
     changed = False
     for adj in adjs:
@@ -417,6 +430,8 @@ def setup() -> None:
 
 
 def step_agent(agent_name: str) -> Optional[str]:
+    # Pick up any PDV changes applied by UI/Discord before we compute/emit.
+    _refresh_pdvs_from_disk()
     global CONTEXT
     os.makedirs("chatlogs", exist_ok=True)
     agent = AGENTS_BY_NAME[agent_name]

--- a/conductor.py
+++ b/conductor.py
@@ -5,6 +5,7 @@ import random
 import shutil
 import argparse
 import threading
+import math
 from datetime import datetime
 from typing import Dict, List, Optional, Iterable
 
@@ -214,8 +215,12 @@ def apply_pdv_adjustments(adjs: List[dict]) -> None:
             changed = True
         m = float(adj.get("delta", 0.0))
         x = float(PDVS.get(name, 0.5))
-        g = (4 * x * (1 - x)) ** gamma
-        x2 = min(1.0, max(0.0, x + m * g))
+        g_base = (4 * x * (1 - x)) ** gamma
+        beta = float(GLOBALS.get("pdv_directional_beta", 0.75))   # 0..1 (how strong the toward/away effect is)
+        alpha = float(GLOBALS.get("pdv_directional_alpha", 0.05)) # scale of typical |delta|
+        boost = 1.0 + beta * math.tanh(((0.5 - x) * m) / max(alpha, 1e-9))
+        x2 = min(1.0, max(0.0, x + m * g_base * boost))
+
         if abs(x2 - x) > 1e-9:
             PDVS[name] = x2
             PDV_META.setdefault(name, {"name": name, "description": ""})

--- a/fenra_ui.py
+++ b/fenra_ui.py
@@ -89,6 +89,13 @@ class _DiscordInUI(discord.Client):
                     norm.append(item)
                 if norm:
                     apply_and_persist_pdv_adjustments(norm)
+                    # Best-effort push to keep conductor in sync immediately.
+                    try:
+                        c = _get_conductor()
+                        if hasattr(c, "_refresh_pdvs_from_disk"):
+                            c._refresh_pdvs_from_disk()
+                    except Exception:
+                        pass
                     print("[PDVM] Applied incoming_message_pdvms on Discord message.")
         except Exception as e:
             print(f"[PDVM] Failed applying incoming_message_pdvms: {e}")


### PR DESCRIPTION
## Summary
- Add `_refresh_pdvs_from_disk` helper to reload PDV state from disk
- Refresh PDVs before applying adjustments and starting agent steps
- UI Discord hook nudges conductor to sync after incoming PDVMs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ace679da90832d9d3aa2779ec8e184