### PR TITLE
Expose full Ollama payloads in Agent Context

### DIFF
--- a/conductor.py
+++ b/conductor.py
@@ -28,6 +28,7 @@ from runtime_utils import (
     parse_log_level,
     create_object_logger,
     tokenize_text,
+    add_json_watcher,
 )
 
 logger = create_object_logger("Conductor")
@@ -612,6 +613,17 @@ if __name__ == "__main__":
     if args.ui:
         try:
             UI = FenraUI(agents=AGENTS)
+
+            def _ui_payload_watcher(p: dict) -> None:
+                try:
+                    agent = p.get("__agent") or STATE.get("current_agent")
+                    if UI and agent:
+                        UI.update_agent_payload(agent, p)
+                except Exception:  # noqa: BLE001
+                    pass
+
+            add_json_watcher(_ui_payload_watcher)
+
             cur = STATE.get("current_agent")
             if isinstance(cur, str) and cur in AGENTS_BY_NAME:
                 UI.set_active_agent(cur)

--- a/conductor.py
+++ b/conductor.py
@@ -456,21 +456,13 @@ def step_agent(agent_name: str) -> Optional[str]:
     )
     prompt = "\n".join(filter(None, [pre, msg, post]))
     if UI is not None:
-        try:
-            UI.set_active_agent(agent["name"])
-            UI.update_agent_payload(
-                agent["name"],
-                {
-                    "model": model_id,
-                    "temperature": temp,
-                    "system_text": system_text,
-                    "pre_text": pre,
-                    "post_text": post,
-                    "message_preview": (msg or "")[-2000:],
-                },
-            )
-        except Exception:
-            logger.exception("UI payload pre-gen update failed")
+       # Do not write the pre-gen “overview” blob to Agent Context.
+       # The runtime_utils JSON watcher will overwrite the panel with the *exact*
+       # payload that is POSTed to Ollama, which is what we want to display.
+       try:
+           UI.set_active_agent(agent["name"])
+       except Exception:
+           logger.exception("UI set_active_agent failed")
     reply = MODEL.generate_from_prompt(
         prompt,
         override_model=model_id,

--- a/runtime_utils.py
+++ b/runtime_utils.py
@@ -335,9 +335,12 @@ def generate_with_watchdog(
     try:
         if wd_logger.isEnabledFor(logging.DEBUG):
             wd_logger.debug("Payload to Ollama:\n%s", json.dumps(payload, indent=2))
+        payload_for_watchers = dict(payload)
+        if agent_name:
+            payload_for_watchers["__agent"] = agent_name
         for func in JSON_WATCHERS:
             try:
-                func(payload)
+                func(payload_for_watchers)
             except Exception:  # noqa: BLE001
                 pass
         resp = requests.post(

--- a/tests/test_json_watcher.py
+++ b/tests/test_json_watcher.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import runtime_utils
+
+
+def test_json_watcher_receives_agent(monkeypatch):
+    received: dict | None = None
+
+    def watcher(payload: dict) -> None:
+        nonlocal received
+        received = payload
+
+    runtime_utils.JSON_WATCHERS.clear()
+    runtime_utils.add_json_watcher(watcher)
+
+    class FakeResp:
+        status_code = 200
+        text = "{}"
+
+        def json(self) -> dict:
+            return {"response": "ok"}
+
+    def fake_post(url, json, timeout):
+        return FakeResp()
+
+    monkeypatch.setattr("requests.post", fake_post)
+
+    runtime_utils.generate_with_watchdog(
+        {"model": "test", "prompt": "hi"}, agent_name="AgentX"
+    )
+
+    assert received is not None
+    assert received.get("__agent") == "AgentX"
+    assert received.get("prompt") == "hi"
+
+    runtime_utils.JSON_WATCHERS.clear()
+


### PR DESCRIPTION
## Summary
- Forward exact payloads (with agent name) to JSON watchers
- Register a watcher in the UI path to display the real outgoing payload per agent
- Add regression test ensuring watchers receive agent-tagged payloads

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ae0d9bd10c832d8d9d65c7c2a75313