### PR TITLE
Expose outgoing Ollama payloads in UI

### DIFF
--- a/conductor.py
+++ b/conductor.py
@@ -610,8 +610,10 @@ if __name__ == "__main__":
                 try:
                     agent = p.get("__agent") or STATE.get("current_agent")
                     if UI and agent:
-                        UI.update_agent_payload(agent, p)
-                except Exception:  # noqa: BLE001
+                        payload = dict(p)
+                        payload.pop("__agent", None)
+                        UI.update_agent_payload(agent, payload)
+                except Exception:
                     pass
 
             add_json_watcher(_ui_payload_watcher)

--- a/runtime_utils.py
+++ b/runtime_utils.py
@@ -335,13 +335,14 @@ def generate_with_watchdog(
     try:
         if wd_logger.isEnabledFor(logging.DEBUG):
             wd_logger.debug("Payload to Ollama:\n%s", json.dumps(payload, indent=2))
+        # Notify UI/watchers with the exact payload that is about to be sent
         payload_for_watchers = dict(payload)
         if agent_name:
             payload_for_watchers["__agent"] = agent_name
         for func in JSON_WATCHERS:
             try:
                 func(payload_for_watchers)
-            except Exception:  # noqa: BLE001
+            except Exception:
                 pass
         resp = requests.post(
             "http://localhost:11434/api/generate",


### PR DESCRIPTION
## Summary
- forward JSON payloads to registered watchers before requests are sent
- update conductor to mirror outgoing payloads in the Agent Context pane
- strip watcher metadata so the Agent Context shows the exact outgoing JSON

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ae2d24ccd0832daef6ba07e7a3e596