### PR TITLE
Add agent-level context ignore controls

### DIFF
--- a/conductor.py
+++ b/conductor.py
@@ -190,28 +190,38 @@ def effective_params(agent: dict):
         temp = cls.get("temperature")
     if temp is None:
         temp = GLOBALS.get("temperature")
-    ignore_global_system = bool(cls.get("ignore_global_system", False))
-    ignore_global_pre = bool(cls.get("ignore_global_pre", False))
-    ignore_global_post = bool(cls.get("ignore_global_post", False))
+    ignore_global_system = bool(cls.get("ignore_global_system", False)) or bool(
+        agent.get("ignore_global_system", False)
+    )
+    ignore_global_pre = bool(cls.get("ignore_global_pre", False)) or bool(
+        agent.get("ignore_global_pre", False)
+    )
+    ignore_global_post = bool(cls.get("ignore_global_post", False)) or bool(
+        agent.get("ignore_global_post", False)
+    )
+
+    ignore_class_system = bool(agent.get("ignore_class_system", False))
+    ignore_class_pre = bool(agent.get("ignore_class_pre", False))
+    ignore_class_post = bool(agent.get("ignore_class_post", False))
 
     system_text = "\n".join(
         [
             ("" if ignore_global_system else GLOBALS.get("system_prompt", "")),
-            cls.get("system_prompt", ""),
+            ("" if ignore_class_system else cls.get("system_prompt", "")),
             agent.get("system_prompt", ""),
         ]
     ).strip()
     pre_text = "\n".join(
         [
             ("" if ignore_global_pre else GLOBALS.get("pre_context_message", "")),
-            cls.get("pre_context_message", ""),
+            ("" if ignore_class_pre else cls.get("pre_context_message", "")),
             agent.get("pre_context_message", ""),
         ]
     ).strip()
     post_text = "\n".join(
         [
             ("" if ignore_global_post else GLOBALS.get("post_context_message", "")),
-            cls.get("post_context_message", ""),
+            ("" if ignore_class_post else cls.get("post_context_message", "")),
             agent.get("post_context_message", ""),
         ]
     ).strip()

--- a/fenra_ui.py
+++ b/fenra_ui.py
@@ -1845,6 +1845,51 @@ class FenraUI:
         _add_text_field("Post-context Message", "post_context_message", height=4)
         _add_text_field("Chat Style", "chat_style", height=4)
 
+        ttk.Label(form, text="Flags").grid(
+            row=row, column=0, sticky="nw", padx=(0, 8), pady=(6, 2)
+        )
+        flags = ttk.Frame(form)
+        flags.grid(row=row, column=1, sticky="w", pady=(6, 2))
+        row += 1
+
+        self.ag_ign_glob_sys = tk.BooleanVar(value=False)
+        self.ag_ign_glob_pre = tk.BooleanVar(value=False)
+        self.ag_ign_glob_post = tk.BooleanVar(value=False)
+        self.ag_ign_cls_sys = tk.BooleanVar(value=False)
+        self.ag_ign_cls_pre = tk.BooleanVar(value=False)
+        self.ag_ign_cls_post = tk.BooleanVar(value=False)
+
+        ttk.Checkbutton(
+            flags,
+            text="Ignore Global System",
+            variable=self.ag_ign_glob_sys,
+        ).pack(side=tk.LEFT, padx=(0, 6))
+        ttk.Checkbutton(
+            flags,
+            text="Ignore Global Pre",
+            variable=self.ag_ign_glob_pre,
+        ).pack(side=tk.LEFT, padx=(0, 6))
+        ttk.Checkbutton(
+            flags,
+            text="Ignore Global Post",
+            variable=self.ag_ign_glob_post,
+        ).pack(side=tk.LEFT, padx=(0, 12))
+        ttk.Checkbutton(
+            flags,
+            text="Ignore Class System",
+            variable=self.ag_ign_cls_sys,
+        ).pack(side=tk.LEFT, padx=(0, 6))
+        ttk.Checkbutton(
+            flags,
+            text="Ignore Class Pre",
+            variable=self.ag_ign_cls_pre,
+        ).pack(side=tk.LEFT, padx=(0, 6))
+        ttk.Checkbutton(
+            flags,
+            text="Ignore Class Post",
+            variable=self.ag_ign_cls_post,
+        ).pack(side=tk.LEFT)
+
         self._active_agent_index = None
         self._loading_agent_form = False
         self._agent_form_vars["model"].trace_add("write", self._update_agent_model_hint)
@@ -1906,6 +1951,13 @@ class FenraUI:
             text_val = agent.get(key)
             if text_val:
                 widget.insert(tk.END, text_val)
+        if hasattr(self, "ag_ign_glob_sys"):
+            self.ag_ign_glob_sys.set(bool(agent.get("ignore_global_system", False)))
+            self.ag_ign_glob_pre.set(bool(agent.get("ignore_global_pre", False)))
+            self.ag_ign_glob_post.set(bool(agent.get("ignore_global_post", False)))
+            self.ag_ign_cls_sys.set(bool(agent.get("ignore_class_system", False)))
+            self.ag_ign_cls_pre.set(bool(agent.get("ignore_class_pre", False)))
+            self.ag_ign_cls_post.set(bool(agent.get("ignore_class_post", False)))
         self._loading_agent_form = False
         self._update_agent_model_hint()
 
@@ -1917,6 +1969,13 @@ class FenraUI:
             var.set("")
         for widget in self._agent_text_fields.values():
             widget.delete("1.0", tk.END)
+        if hasattr(self, "ag_ign_glob_sys"):
+            self.ag_ign_glob_sys.set(False)
+            self.ag_ign_glob_pre.set(False)
+            self.ag_ign_glob_post.set(False)
+            self.ag_ign_cls_sys.set(False)
+            self.ag_ign_cls_pre.set(False)
+            self.ag_ign_cls_post.set(False)
         self._loading_agent_form = False
         self._update_agent_model_hint()
 
@@ -1984,6 +2043,14 @@ class FenraUI:
             else:
                 agent.pop(key, None)
 
+        if hasattr(self, "ag_ign_glob_sys"):
+            agent["ignore_global_system"] = bool(self.ag_ign_glob_sys.get())
+            agent["ignore_global_pre"] = bool(self.ag_ign_glob_pre.get())
+            agent["ignore_global_post"] = bool(self.ag_ign_glob_post.get())
+            agent["ignore_class_system"] = bool(self.ag_ign_cls_sys.get())
+            agent["ignore_class_pre"] = bool(self.ag_ign_cls_pre.get())
+            agent["ignore_class_post"] = bool(self.ag_ign_cls_post.get())
+
         agent.setdefault("groups_in", [])
         agent.setdefault("groups_out", [])
 
@@ -2027,6 +2094,12 @@ class FenraUI:
             "agent_class": "",
             "groups_in": [],
             "groups_out": [],
+            "ignore_global_system": False,
+            "ignore_global_pre": False,
+            "ignore_global_post": False,
+            "ignore_class_system": False,
+            "ignore_class_pre": False,
+            "ignore_class_post": False,
         }
         self._agents_model.append(new_agent)
         self._refresh_agent_listbox(select_index=len(self._agents_model) - 1)


### PR DESCRIPTION
## Summary
- add per-agent UI controls to toggle inclusion of global and class contexts
- persist the new flags with agents and default them on creation
- respect per-agent ignore settings when composing prompts in the conductor

## Testing
- python -m compileall fenra_ui.py conductor.py

------
https://chatgpt.com/codex/tasks/task_e_68ebcf6c5dec832dab0a72de5b854249