### PR TITLE
Fix UI threading and missing agent handling

### DIFF
--- a/conductor.py
+++ b/conductor.py
@@ -765,24 +765,26 @@ def step_agent(agent_name: str) -> Optional[str]:
     return nxt["name"] if nxt else None
 
 
-def _ensure_current_agent() -> str:
-    """Ensure STATE["current_agent"] is populated and return its value."""
+def _ensure_current_agent() -> str | None:
+    """Return STATE['current_agent'] or first configured agent, else None."""
 
     cur = STATE.get("current_agent")
     if isinstance(cur, str) and cur:
         return cur
     if AGENTS:
         candidate = next((a.get("name") for a in AGENTS if a.get("name")), None)
-        if candidate is None:
-            raise RuntimeError("No agents configured; cannot start loop")
-        STATE["current_agent"] = candidate
-        save_state(STATE)
-        return candidate
-    raise RuntimeError("No agents configured; cannot start loop")
+        if candidate:
+            STATE["current_agent"] = candidate
+            save_state(STATE)
+            return candidate
+    logger.warning("No agents configured – agent loop will idle")
+    return None
 
 
 def run_loop(steps: Optional[int] = None) -> None:
     cur = _ensure_current_agent()
+    if cur is None:
+        return  # nothing to run
     hist: List[str] = [cur]
     count = 0
     while steps is None or count < steps:

--- a/fenra_ui.py
+++ b/fenra_ui.py
@@ -12,6 +12,7 @@ from typing import Optional, Callable
 import tkinter as tk
 from tkinter import scrolledtext, simpledialog, filedialog, messagebox
 from tkinter import ttk
+import queue
 
 import discord
 import requests
@@ -249,6 +250,9 @@ class FenraUI:
             send_callback,
         )
         self.root = tk.Tk()
+        self._pending_calls: queue.Queue[tuple[Callable, tuple, dict]] = queue.Queue()
+        self._ui_closed = False
+        self.root.after(20, self._process_pending)
         self.root.title("Fenra")
         self.agents = agents
         self.inject_callback = inject_callback
@@ -696,6 +700,7 @@ class FenraUI:
         self._config_watch_thread = None
 
     def _on_close(self) -> None:
+        self._ui_closed = True
         self._stop_config_watcher()
         try:
             self.root.destroy()
@@ -3407,11 +3412,22 @@ class FenraUI:
         widget.see(tk.END)
         widget.configure(state="disabled")
 
+    def _process_pending(self) -> None:
+        while not self._pending_calls.empty():
+            func, args, kwargs = self._pending_calls.get_nowait()
+            try:
+                func(*args, **kwargs)
+            except Exception:
+                logger.exception("UI callback failed")
+        # reschedule itself so it keeps draining
+        if not getattr(self, "_ui_closed", False):
+            self.root.after(20, self._process_pending)
+
     def _threadsafe(self, func, *args, **kwargs) -> None:
         if threading.current_thread() is threading.main_thread():
             func(*args, **kwargs)
         else:
-            self.root.after(0, lambda: func(*args, **kwargs))
+            self._pending_calls.put((func, args, kwargs))
 
     def _expand_all(self):
         logger.debug("_expand_all called but tree view removed")


### PR DESCRIPTION
## Summary
- queue UI callbacks on the main thread and drain them safely while the Fenra UI is open
- mark the UI loop as closed on shutdown so pending work stops rescheduling
- fall back gracefully when no agents are configured and skip the run loop instead of crashing

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'requests')*


------
https://chatgpt.com/codex/tasks/task_e_68ee7bbc3458832d879a4e3d9023b492