### PR TITLE
Allow config tabs to load without config files

### DIFF
--- a/fenra_ui.py
+++ b/fenra_ui.py
@@ -937,19 +937,10 @@ class FenraUI:
         for child in self.globals_tab.winfo_children():
             child.destroy()
         self._globals_vars = {}
-        if not self._have_conf("globals.json"):
-            self.global_config = {}
-            self.base_timeout = self.global_config.get("watchdog_timeout", 900)
-            if hasattr(self, "timeout_label"):
-                txt = (
-                    "Base Timeout: disabled"
-                    if (self.base_timeout is None or float(self.base_timeout) <= 0)
-                    else f"Base Timeout: {int(self.base_timeout)}s"
-                )
-                self.timeout_label.config(text=txt)
+        missing = not self._have_conf("globals.json")
+        self.global_config = {} if missing else self._ui_globals()
+        if missing:
             self._missing_conf_panel(self.globals_tab, "globals.json")
-            return
-        self.global_config = self._ui_globals()
         models = self._fetch_models()
         self._globals_vars = {
             "debug_level": tk.StringVar(value=self.global_config.get("debug_level", "INFO")),
@@ -1046,16 +1037,12 @@ class FenraUI:
         for child in self.pdvs_tab.winfo_children():
             child.destroy()
         self._pdv_rows = []
-        if not self._have_conf("pdvs.json"):
-            self.pdv_values = {}
-            self._pdv_names = []
-            self._missing_conf_panel(self.pdvs_tab, "pdvs.json")
-            if getattr(self, "metrics_rows", None):
-                self._rebuild_live_metrics_rows()
-            return
-        pdvs = self._ui_pdvs()
+        missing = not self._have_conf("pdvs.json")
+        pdvs = {} if missing else self._ui_pdvs()
         self.pdv_values = {name: cfg.get("value", 0.0) for name, cfg in pdvs.items()}
         self._pdv_names = sorted(pdvs.keys())
+        if missing:
+            self._missing_conf_panel(self.pdvs_tab, "pdvs.json")
         frame = self.pdvs_tab
         for name, cfg in pdvs.items():
             self._add_pdv_row(frame, name, cfg)
@@ -1112,34 +1099,16 @@ class FenraUI:
     def _build_classes_tab(self) -> None:
         for child in self.classes_tab.winfo_children():
             child.destroy()
-
-        if not self._have_conf("classes.json"):
-            self._classes_map = {}
-            self.cls_list = tk.Listbox(self.classes_tab, exportselection=False)
-            self.cls_save_btn = ttk.Button(self.classes_tab, state="disabled")
-            self.cls_name = tk.StringVar()
-            self.cls_trig = tk.StringVar()
-            self.cls_trig_cb = ttk.Combobox(self.classes_tab, state="disabled")
-            self.cls_model = tk.StringVar()
-            self.cls_model_cb = ttk.Combobox(self.classes_tab, state="disabled")
-            self.cls_temp = tk.DoubleVar(value=1.0)
-            self.cls_temp_inherit = tk.BooleanVar(value=True)
-            self.cls_temp_scale = ttk.Scale(self.classes_tab, from_=0.0, to=2.0, orient=tk.HORIZONTAL)
-            self.cls_temp_label = ttk.Label(self.classes_tab, text="")
-            self.cls_sys = scrolledtext.ScrolledText(self.classes_tab)
-            self.cls_pre = scrolledtext.ScrolledText(self.classes_tab)
-            self.cls_post = scrolledtext.ScrolledText(self.classes_tab)
-            self.pdv_rows_container = ttk.Frame(self.classes_tab)
-            self._pdv_row_widgets = []
-            self._missing_conf_panel(self.classes_tab, "classes.json")
-            return
-
-        self._classes_map = self._ui_classes()
+        missing = not self._have_conf("agent_classes.json")
+        self._classes_map = {} if missing else self._ui_classes()
         for c in self._classes_map.values():
             if "pdv_adjustments" in c:
                 c["pdv_adjustments"] = [
                     a for a in c.get("pdv_adjustments", []) if a.get("name") in self._pdv_names
                 ]
+
+        if missing:
+            self._missing_conf_panel(self.classes_tab, "agent_classes.json")
 
         container = ttk.Frame(self.classes_tab)
         container.pack(fill=tk.BOTH, expand=True)
@@ -1740,18 +1709,10 @@ class FenraUI:
             return
         for child in frame.winfo_children():
             child.destroy()
-        if not self._have_conf("agents.json"):
-            self._agents_model = []
-            self._active_agent_index = None
-            self.agent_list = None
-            self._agent_form_vars = {}
-            self._agent_text_fields = {}
-            self._agent_class_cb = None
-            self._agent_model_hint = None
+        missing = not self._have_conf("agents.json")
+        self._agents_model = [] if missing else self._ui_agents()
+        if missing:
             self._missing_conf_panel(frame, "agents.json")
-            return
-
-        self._agents_model = self._ui_agents()
 
         paned = ttk.Panedwindow(frame, orient=tk.HORIZONTAL)
         paned.pack(fill=tk.BOTH, expand=True)
@@ -2142,13 +2103,11 @@ class FenraUI:
             return
         for child in frame.winfo_children():
             child.destroy()
-        if not self._have_conf("agents.json"):
-            self._agents_cache = []
-            self._missing_conf_panel(frame, "agents.json")
-            return
-
-        agents = self._ui_agents()
+        missing = not self._have_conf("agents.json")
+        agents = [] if missing else self._ui_agents()
         self._agents_cache = agents
+        if missing:
+            self._missing_conf_panel(frame, "agents.json")
 
         flagged = [a for a in agents if a.get("flag_no_downstream")]
         if flagged:
@@ -2283,21 +2242,21 @@ class FenraUI:
         return (self._conf_dir_path / name).is_file()
 
     def _missing_conf_panel(self, parent: tk.Widget, name: str) -> None:
-        frame = ttk.Frame(parent, padding=24)
-        frame.pack(fill=tk.BOTH, expand=True)
+        frame = ttk.Frame(parent, padding=8, relief=tk.GROOVE, borderwidth=1)
+        frame.pack(fill=tk.X, padx=6, pady=(6, 8))
         ttk.Label(
             frame,
             text=f"⚠ '{name}' not found in '{self._conf_dir_path.name}'.",
             foreground="#b94a48",
-            wraplength=360,
-            justify=tk.CENTER,
-        ).pack(pady=(0, 6))
+            wraplength=480,
+            justify=tk.LEFT,
+        ).pack(anchor="w")
         ttk.Label(
             frame,
-            text="Create the file to enable this view.",
-            wraplength=360,
-            justify=tk.CENTER,
-        ).pack()
+            text="A new file will be created automatically when you save.",
+            wraplength=480,
+            justify=tk.LEFT,
+        ).pack(anchor="w")
 
     def _ui_globals(self) -> dict:
         data = try_load_globals()
@@ -2340,7 +2299,7 @@ class FenraUI:
                     self._ensure_globals_set()
             elif name == "pdvs.json":
                 self._build_pdvs_tab()
-            elif name == "classes.json":
+            elif name == "agent_classes.json":
                 self._build_classes_tab()
                 if present:
                     self._restore_class_tab_selection()


### PR DESCRIPTION
## Summary
- keep configuration editors usable when their JSON files are absent by building the UI with default state and showing a non-blocking banner
- update the Agent Classes tab and file watcher to use `agent_classes.json`
- reuse the new banner styling across tabs so saving will create the missing files

## Testing
- python -m compileall fenra_ui.py

------
https://chatgpt.com/codex/tasks/task_e_68ee818ac03c832da4c25302f7d3703f