### PR TITLE
Fix Tk UI calls from background threads

### DIFF
--- a/fenra_ui.py
+++ b/fenra_ui.py
@@ -5,6 +5,7 @@ import asyncio
 from pathlib import Path
 from datetime import datetime
 import threading
+import queue
 import time
 import hashlib
 import colorsys
@@ -277,6 +278,10 @@ class FenraUI:
         self._config_watch_thread: threading.Thread | None = None
         self._config_observer = None
         self._config_update_pending = False
+        # --- UI thread handoff queue ---
+        self._ui_queue: "queue.Queue[tuple[Callable, tuple, dict]]" = queue.Queue()
+        # Start a pump that runs ONLY on the Tk thread and executes queued callables.
+        self.root.after(0, self._pump_ui_queue)
         self._missing_configs: list[str] = []
 
         self._classes_map: dict[str, dict] = self._ui_classes()
@@ -608,10 +613,8 @@ class FenraUI:
             self._update_required_configs_state()
 
         self._config_update_pending = True
-        try:
-            self.root.after(150, _run)
-        except tk.TclError:
-            self._config_update_pending = False
+        # Ensure the timer is registered from the Tk thread.
+        self._threadsafe(self.root.after, 150, _run)
 
     def _update_required_configs_state(self) -> None:
         # Compute presence strictly by existence on disk.
@@ -3710,10 +3713,31 @@ class FenraUI:
         widget.configure(state="disabled")
 
     def _threadsafe(self, func, *args, **kwargs) -> None:
+        """Ensure ``func`` runs on the Tk main thread."""
+
         if threading.current_thread() is threading.main_thread():
-            func(*args, **kwargs)
+            try:
+                func(*args, **kwargs)
+            except Exception:
+                logger.exception("UI task failed")
         else:
-            self.root.after(0, lambda: func(*args, **kwargs))
+            self._ui_queue.put((func, args, kwargs))
+
+    def _pump_ui_queue(self) -> None:
+        """Drain pending UI work enqueued from background threads."""
+
+        try:
+            while True:
+                func, args, kwargs = self._ui_queue.get_nowait()
+                try:
+                    func(*args, **kwargs)
+                except Exception:
+                    logger.exception("Queued UI task failed")
+        except queue.Empty:
+            pass
+
+        # Schedule the next pump; ~60 FPS cadence keeps latency low without churn.
+        self.root.after(16, self._pump_ui_queue)
 
     def _expand_all(self):
         logger.debug("_expand_all called but tree view removed")


### PR DESCRIPTION
## Summary
- add a UI task queue pumped from the Tk main loop so worker threads never touch Tk APIs
- update _threadsafe and required config scheduling to enqueue work instead of calling after from background threads

## Testing
- python -m compileall fenra_ui.py

------
https://chatgpt.com/codex/tasks/task_e_68f4056b14e8832dad02a964d55279c5