### PR TITLE
Implement additive Discord PDV adjustments

### DIFF
--- a/fenra_discord.py
+++ b/fenra_discord.py
@@ -75,7 +75,7 @@ class DiscordToFenra(discord.Client):
             if pdv_name and scale > 0:
                 delta = len(msg.content or "") * scale
                 if delta != 0:
-                    apply_and_persist_pdv_adjustments([{"pdv": pdv_name, "delta": delta}])
+                    apply_and_persist_pdv_adjustments([{"name": pdv_name, "delta": delta}])
                     print(f"[PDVM] Discord adjusted {pdv_name} by +{delta:.3f}")
         except Exception as e:
             print(f"[Discord→Fenra] Discord PDV update failed: {e}")

--- a/fenra_ui.py
+++ b/fenra_ui.py
@@ -112,7 +112,7 @@ class _DiscordInUI(discord.Client):
             if pdv_name and scale > 0:
                 delta = len(msg.content or "") * scale
                 if delta != 0:
-                    apply_and_persist_pdv_adjustments([{"pdv": pdv_name, "delta": delta}])
+                    apply_and_persist_pdv_adjustments([{"name": pdv_name, "delta": delta}])
                     try:
                         c = _get_conductor()
                         if hasattr(c, "_refresh_pdvs_from_disk"):

--- a/pdv_utils.py
+++ b/pdv_utils.py
@@ -1,77 +1,27 @@
-import os
-import time
-import json
-import math
-from typing import List, Dict
-from config_loader import load_pdvs, save_pdvs
+from __future__ import annotations
+
+from typing import Dict, List
+import importlib
 
 
-def _clamp01(x: float) -> float:
-    return 0.0 if x < 0.0 else 1.0 if x > 1.0 else x
+def apply_and_persist_pdv_adjustments(adjs: List[Dict], *, scale: float = 1.0) -> None:
+    """
+    Normalize PDV adjustments and forward them to Conductor's additive updater.
+    No upper clamp; floor at zero is handled by Conductor.
+    """
+    # Import lazily to avoid circular imports if called from UI/Discord.
+    conductor = importlib.import_module("conductor")
 
-
-def _ensure_dirs() -> None:
-    os.makedirs("chatlogs", exist_ok=True)
-
-
-def _pdv_values_map(pdvs_cfg: Dict[str, dict]) -> Dict[str, float]:
-    return {name: float(cfg.get("value", 0.5)) for name, cfg in pdvs_cfg.items()}
-
-
-def apply_and_persist_pdv_adjustments(adjs: List[dict]) -> Dict[str, float]:
-    """Apply PDV deltas with logistic shaping and persist history/live files."""
-    gamma = 2.0
-
-    try:
-        pdvs_cfg = load_pdvs()
-        pdvs_loaded = True
-    except Exception:
-        pdvs_cfg = {}
-        pdvs_loaded = False
-    values = _pdv_values_map(pdvs_cfg)
-
-    changed = False
-    for item in adjs or []:
-        name = item.get("name") or item.get("pdv")
-        if not isinstance(name, str) or not name.strip():
+    norm: list[dict] = []
+    for a in adjs or []:
+        name = a.get("name") or a.get("pdv")
+        if not name:
             continue
+        delta = float(a.get("delta", 0.0))
+        norm.append({"name": name, "delta": delta})
 
-        if "delta_pct" in item:
-            try:
-                delta = float(item["delta_pct"])
-            except Exception:
-                continue
-        elif "delta" in item:
-            try:
-                delta = float(item["delta"])
-            except Exception:
-                continue
-        else:
-            continue
-        if not math.isfinite(delta):
-            continue
+    if not norm:
+        return
 
-        x = float(values.get(name, 0.5))
-        g = (4.0 * x * (1.0 - x)) ** gamma
-        x2 = _clamp01(x + delta * g)
-
-        if abs(x2 - x) > 1e-12:
-            values[name] = x2
-            if name not in pdvs_cfg:
-                pdvs_cfg[name] = {"name": name, "description": "", "value": x2}
-            else:
-                pdvs_cfg[name]["value"] = x2
-            print(f"[PDVM] {name}: {x:.4f} -> {x2:.4f}")
-            changed = True
-
-    if changed:
-        if pdvs_loaded:
-            save_pdvs(pdvs_cfg)
-        _ensure_dirs()
-        with open(os.path.join("chatlogs", "pdv_history.jsonl"), "a", encoding="utf-8") as f:
-            f.write(json.dumps({"ts": time.time(), "pdvs": values}, ensure_ascii=False) + "\n")
-        with open(os.path.join("chatlogs", "pdvs_live.json"), "w", encoding="utf-8") as f:
-            json.dump(values, f)
-        print("[PDVM] Discord-triggered PDVMs applied.")
-
-    return values
+    # Conductor applies +delta * scale, floors at 0, persists pdvs.json and history.
+    conductor.apply_pdv_adjustments(norm, scale=scale)


### PR DESCRIPTION
## Summary
- replace the legacy PDV utility with a thin wrapper that forwards additive deltas to the conductor without clamping
- update Discord message handlers in the UI and legacy client to send normalized PDV adjustment payloads keyed by name

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f4428d58cc832d8a8a3bb37b995d58