### PR TITLE
Add live PowerShell console to Internal Thoughts tab

### DIFF
--- a/conductor.py
+++ b/conductor.py
@@ -861,7 +861,24 @@ def step_agent(agent_name: str) -> Optional[str]:
     commands = _extract_pwsh_commands(reply)
     if commands:
         for cmd in commands:
+            cwd_before = _run_powershell("(Get-Location).Path")
+            if UI is not None and hasattr(UI, "append_ps"):
+                try:
+                    UI.append_ps(f"PS {cwd_before}> {cmd}")
+                except Exception:
+                    logger.exception("UI append_ps failed for command prompt")
             ps_out = _run_powershell(cmd)
+            if UI is not None and hasattr(UI, "append_ps"):
+                try:
+                    UI.append_ps(ps_out)
+                except Exception:
+                    logger.exception("UI append_ps failed for command output")
+            cwd_after = _run_powershell("(Get-Location).Path")
+            if UI is not None and hasattr(UI, "append_ps"):
+                try:
+                    UI.append_ps(f"PS {cwd_after}> ")
+                except Exception:
+                    logger.exception("UI append_ps failed for next prompt")
             reply += f"\nCommand Run: {cmd}\nPowerShell Output: {ps_out}\n"
 
     cls = CLASSES[agent["agent_class"]]

--- a/fenra_ui.py
+++ b/fenra_ui.py
@@ -14,6 +14,7 @@ from typing import Optional, Callable
 import tkinter as tk
 from tkinter import scrolledtext, simpledialog, filedialog, messagebox
 from tkinter import ttk
+from tkinter import font as tkfont
 
 import discord
 import requests
@@ -431,7 +432,20 @@ class FenraUI:
         self.thought_stream = scrolledtext.ScrolledText(thought_frame, state="disabled")
         self.thought_stream.pack(fill=tk.BOTH, expand=True)
 
-        self.events_stream = scrolledtext.ScrolledText(event_frame, state="disabled")
+        ttk.Label(event_frame, text="PowerShell Console").pack(anchor="w", padx=4, pady=(0, 2))
+
+        try:
+            console_font = tkfont.nametofont("TkFixedFont")
+        except tk.TclError:
+            console_font = tkfont.Font(family="Consolas", size=10)
+        self._console_font = console_font
+
+        self.events_stream = scrolledtext.ScrolledText(
+            event_frame,
+            state="disabled",
+            wrap=tk.NONE,
+            font=self._console_font,
+        )
         self.events_stream.pack(fill=tk.BOTH, expand=True)
 
         # Backward compatibility
@@ -895,6 +909,27 @@ class FenraUI:
 
         self._threadsafe(_append)
         logger.debug("Exiting append_event")
+
+    def append_ps(self, line: str) -> None:
+        logger.debug("Entering append_ps line=%s", line)
+
+        def _append():
+            txt = line if line.endswith("\n") else f"{line}\n"
+            self._append_text(self.events_stream, txt)
+
+        self._threadsafe(_append)
+        logger.debug("Exiting append_ps")
+
+    def clear_ps(self) -> None:
+        logger.debug("Entering clear_ps")
+
+        def _do():
+            self.events_stream.configure(state="normal")
+            self.events_stream.delete("1.0", tk.END)
+            self.events_stream.configure(state="disabled")
+
+        self._threadsafe(_do)
+        logger.debug("Exiting clear_ps")
 
     def update_queue_and_sent(self, queued: Optional[list] = None, sent: Optional[list] = None) -> None:
         logger.debug("Entering update_queue_and_sent queued=%s sent=%s", queued, sent)


### PR DESCRIPTION
## Summary
- restyle the Internal Thoughts right pane as a PowerShell console with helper methods
- stream PowerShell prompts and outputs from executed commands into the console

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f5582c50dc832d8f4d5bd047322dd7