### PR TITLE
Enforce whitespace-free Fenra call extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,27 @@ User messages are queued by appending JSON objects to `chatlogs/queued_messages.
 - Speaker-class outputs are mirrored to `chatlogs/messages_to_humans.json` (for the UI "Sent (to humans)" tab).
 - The message queue lives at `chatlogs/queued_messages.json` and is cleared when a queue-reading agent consumes it.
 - Hot reload of configs is planned but not yet implemented.
+
+## Codex Prompt (system instructions)
+
+Use the following global/system prompt so that agents emit Fenra function calls correctly:
+
+```
+**Fenra function-call protocol (strict)**
+
+* Use `*~` and `~*` to invoke Fenra functions: `*~function_name(args)~*`.
+* **No-whitespace rule:** There must be **zero** whitespace characters (spaces, tabs, or newlines) **anywhere** between the opening `*~` and the closing `~*`.
+  If any whitespace would appear between the markers, the entire sequence must be treated as **plain text**, not a function call.
+* Emit each call on its own line. Never place calls inside code fences or other markup. Do not add commentary inside the markers.
+* Examples:
+
+  * ✅ Valid: `*~list_agents()~*`
+  * ✅ Valid: `*~duplicate_self()~*`
+  * ❌ Ignore: `*~ list_agents()~*` (leading space)
+  * ❌ Ignore: `*~list_agents ()~*` (space before parentheses)
+  * ❌ Ignore: `*~list agents()~*` (space in name)
+  * ❌ Ignore: `*~some_call("two words")~*` (space inside the arguments)
+* If you cannot express something without spaces inside the markers, **do not** wrap it in `*~…~*`; write normal text instead.
+
+(This prompt governs how you write calls; extraction of calls is done by the Conductor after generation.)
+```

--- a/conductor.py
+++ b/conductor.py
@@ -67,8 +67,17 @@ def _clip(text: str, limit: int = 8000) -> str:
     return f"{head}\n…[truncated {len(t)-6000} chars]…\n{tail}"
 
 
+def _is_valid_call_span(span: str) -> bool:
+    """Return True if the span contains no whitespace characters."""
+
+    return not re.search(r"\s", span)
+
+
 def _extract_pwsh_commands(text: str) -> list[str]:
-    return re.findall(r"\*~(.*?)~\*", text or "", flags=re.DOTALL)
+    """Extract *~...~* call spans that obey the no-whitespace rule."""
+
+    spans = re.findall(r"\*~(.*?)~\*", text or "", flags=re.DOTALL)
+    return [s for s in spans if _is_valid_call_span(s)]
 
 
 def _ps_timeout_seconds() -> int:

--- a/fenra_functions.py
+++ b/fenra_functions.py
@@ -212,3 +212,21 @@ def duplicate_self() -> str:
 
     return f"Duplicated {base} → {name}"
 
+
+@register("list_agents", "Return the names of all agents currently loaded.")
+def list_agents() -> str:
+    """
+    List the name of all agents within the network (one per line).
+    """
+    import importlib
+
+    conductor = importlib.import_module("conductor")
+    # Ensure configs are loaded so AGENTS/AGENTS_BY_NAME are populated
+    if not getattr(conductor, "_CONFIGS_LOADED", False) and hasattr(conductor, "ensure_configs_loaded"):
+        try:
+            conductor.ensure_configs_loaded()
+        except Exception:
+            pass
+    names = sorted([a.get("name") for a in getattr(conductor, "AGENTS", []) if a.get("name")])
+    return "\n".join(names) if names else "(no agents loaded)"
+


### PR DESCRIPTION
## Summary
- add a helper to validate Fenra call spans for disallowed whitespace
- update `_extract_pwsh_commands` to return only whitespace-free call spans

## Testing
- python - <<'PY' (fails: ModuleNotFoundError for optional dependency `requests`)


------
https://chatgpt.com/codex/tasks/task_e_68f7fa71d28c832d94faccaadec43e3a