### PR TITLE
Add call_agent override and relax call span whitespace validation

### DIFF
--- a/conductor.py
+++ b/conductor.py
@@ -68,15 +68,16 @@ def _clip(text: str, limit: int = 8000) -> str:
 
 
 def _is_valid_call_span(span: str) -> bool:
-    """Return True if the span has no leading or trailing whitespace."""
-
-    if not isinstance(span, str) or not span:
+    """Return True iff the span is non-empty and has no leading/trailing whitespace.
+    Internal whitespace is allowed."""
+    if not isinstance(span, str):
         return False
-    return not span[0].isspace() and not span[-1].isspace()
+    trimmed = span.strip()
+    return bool(trimmed) and (trimmed == span)
 
 
 def _extract_pwsh_commands(text: str) -> list[str]:
-    """Extract *~...~* call spans that keep whitespace away from the markers."""
+    """Extract *~...~* call spans that have no leading/trailing whitespace."""
 
     spans = re.findall(r"\*~(.*?)~\*", text or "", flags=re.DOTALL)
     return [s for s in spans if _is_valid_call_span(s)]
@@ -963,6 +964,9 @@ def step_agent(agent_name: str) -> Optional[str]:
             UI.set_group_contexts(_read_group_contexts())
         except Exception:
             logger.exception("UI post-gen update failed")
+    override = STATE.pop("force_next_agent", None)
+    if isinstance(override, str) and override in AGENTS_BY_NAME:
+        return override
     if used > GLOBALS.get("max_context_tokens", 8192):
         arch_cand = find_archivist_downstream(agent)
         if arch_cand:

--- a/fenra_functions.py
+++ b/fenra_functions.py
@@ -323,3 +323,38 @@ def list_agents() -> str:
     names = sorted([a.get("name") for a in getattr(conductor, "AGENTS", []) if a.get("name")])
     return "\n".join(names) if names else "(no agents loaded)"
 
+
+@register(
+    "call_agent",
+    "Set which agent runs next. Usage: call_agent() to re-run the caller, or call_agent(\"Agent Name\")."
+)
+def call_agent(*args) -> str:
+    import importlib, re
+    conductor = importlib.import_module("conductor")
+
+    # Ensure runtime is initialized so STATE/AGENTS_BY_NAME are available
+    if not getattr(conductor, "_CONFIGS_LOADED", False) and hasattr(conductor, "ensure_configs_loaded"):
+        try:
+            conductor.ensure_configs_loaded()
+        except Exception:
+            pass
+
+    # Resolve target name
+    if len(args) == 0:
+        target = (getattr(conductor, "STATE", {}) or {}).get("current_agent")
+        if not isinstance(target, str) or target not in conductor.AGENTS_BY_NAME:
+            return "call_agent: current agent is not set or cannot be found"
+    elif len(args) == 1:
+        # Back-compat: allow underscores to mean spaces
+        raw = str(args[0] or "")
+        target = re.sub(r"\s+", " ", raw.replace("_", " ")).strip()
+        if not target:
+            return "call_agent: agent name cannot be empty"
+        if target not in conductor.AGENTS_BY_NAME:
+            return f"call_agent: '{target}' not found"
+    else:
+        return 'Usage: call_agent() or call_agent("Agent Name")'
+
+    conductor.STATE["force_next_agent"] = target
+    return f"Next agent set to: {target}"
+


### PR DESCRIPTION
## Summary
- allow function-call spans to contain internal whitespace while still rejecting leading/trailing whitespace
- add a Fenra call_agent helper that lets agents force who runs next
- honor the force_next_agent override inside the step loop before fallback selection

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f82eaae888832d87d522050b810072