### PR TITLE
Add Fenra Discord helpers for message counts and range retrieval

### DIFF
--- a/fenra_functions.py
+++ b/fenra_functions.py
@@ -133,6 +133,9 @@ def get_discord_message_count() -> str:
 
     try:
         fe = importlib.import_module("fenra_ui")
+        ensure = getattr(fe, "ensure_discord_running", None)
+        if callable(ensure) and not ensure():
+            return "(error) Discord not configured or unavailable"
         if hasattr(fe, "count_discord_messages"):
             return str(int(fe.count_discord_messages()))
     except Exception as e:
@@ -151,6 +154,10 @@ def get_discord_messages(*args) -> str:
         fe = importlib.import_module("fenra_ui")
     except Exception as e:
         return f"(error) {type(e).__name__}: {e}"
+
+    ensure = getattr(fe, "ensure_discord_running", None)
+    if callable(ensure) and not ensure():
+        return "(error) Discord not configured or unavailable"
 
     if len(args) == 0:
         try:

--- a/fenra_functions.py
+++ b/fenra_functions.py
@@ -124,6 +124,75 @@ def announce_self() -> str:
     return f"The agent who ran this function is named '{name}'"
 
 
+@register(
+    "get_discord_message_count",
+    "Return the total number of messages in the configured Discord channel.",
+)
+def get_discord_message_count() -> str:
+    import importlib
+
+    try:
+        fe = importlib.import_module("fenra_ui")
+        if hasattr(fe, "count_discord_messages"):
+            return str(int(fe.count_discord_messages()))
+    except Exception as e:
+        return f"(error) {type(e).__name__}: {e}"
+    return "0"
+
+
+@register(
+    "get_discord_messages",
+    "Get Discord messages. Forms: get_discord_messages(); get_discord_messages(n); get_discord_messages(m, n). Two-arg form is 1-based from oldest (m=start index, n=count).",
+)
+def get_discord_messages(*args) -> str:
+    import importlib
+
+    try:
+        fe = importlib.import_module("fenra_ui")
+    except Exception as e:
+        return f"(error) {type(e).__name__}: {e}"
+
+    if len(args) == 0:
+        try:
+            msgs = fe.fetch_recent_discord_messages(1) or []
+            if not msgs:
+                return "(no messages)"
+            m = msgs[0]
+            return m.get("text") or ""
+        except Exception as e:
+            return f"(error) {type(e).__name__}: {e}"
+
+    if len(args) == 1:
+        try:
+            n = max(1, int(args[0]))
+        except Exception:
+            return "(error) ValueError: expected integer 'n'"
+        try:
+            recent = fe.fetch_recent_discord_messages(n) or []
+            recent = list(reversed(recent))
+            lines = [it.get("text", "") for it in recent if (it.get("text") or "").strip()]
+            return "\n".join(lines) if lines else "(no messages)"
+        except Exception as e:
+            return f"(error) {type(e).__name__}: {e}"
+
+    if len(args) == 2:
+        try:
+            m = max(1, int(args[0]))
+            n = max(0, int(args[1]))
+        except Exception:
+            return "(error) ValueError: expected integers 'm, n'"
+        if n == 0:
+            return ""
+        try:
+            items = fe.fetch_discord_messages_slice(m, n) or []
+            lines = [it.get("text", "") for it in items if (it.get("text") or "").strip()]
+            return "\n".join(lines) if lines else "(no messages)"
+        except Exception as e:
+            return f"(error) {type(e).__name__}: {e}"
+
+    return "(error) ValueError: get_discord_messages accepts 0, 1, or 2 arguments"
+
+
 @register("fenra_powershell", "Execute a PowerShell command string and return its output.")
 def fenra_powershell(command: str) -> str:
     """

--- a/fenra_ui.py
+++ b/fenra_ui.py
@@ -182,6 +182,73 @@ async def stop_discord_in_ui():
         _discord_consumer_task.cancel()
     print("[UI/Discord] Listening stopped.")
 
+
+def ensure_discord_running(timeout: float = 5.0) -> bool:
+    """Start the Discord client in a background loop when running headless."""
+
+    global _discord_client, _discord_loop, _discord_task
+
+    token = os.getenv("fenra_token")
+    chan = os.getenv("DISCORD_CHANNEL_ID")
+    if not token or not chan:
+        return False
+
+    client = _discord_client
+    if client is not None:
+        try:
+            if client.is_ready():
+                return True
+        except Exception:
+            pass
+
+    loop = _discord_loop
+    if loop is None or not loop.is_running():
+
+        def _run_loop() -> None:
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+            globals()["_discord_loop"] = loop
+            try:
+                loop.run_until_complete(start_discord_in_ui())
+            except Exception:
+                pass
+            try:
+                loop.run_forever()
+            finally:
+                loop.close()
+
+        threading.Thread(target=_run_loop, daemon=True).start()
+    else:
+        need_restart = _discord_client is None
+        task = _discord_task
+        if not need_restart and task is not None:
+            try:
+                need_restart = task.done()
+            except Exception:
+                need_restart = True
+        if need_restart:
+            try:
+                asyncio.run_coroutine_threadsafe(start_discord_in_ui(), loop)
+            except Exception:
+                pass
+
+    deadline = time.time() + max(0.0, float(timeout))
+    while time.time() < deadline:
+        client = _discord_client
+        if client is not None:
+            try:
+                if client.is_ready():
+                    return True
+            except Exception:
+                pass
+        time.sleep(0.1)
+
+    client = _discord_client
+    try:
+        return bool(client and client.is_ready())
+    except Exception:
+        return False
+
 # ─── public: fetch recent discord messages for listeners ──────────────────────
 async def _discord_fetch_recent(n: int) -> list[dict]:
     """Coroutine to fetch last n messages from configured channel."""

--- a/fenra_ui.py
+++ b/fenra_ui.py
@@ -223,6 +223,103 @@ def fetch_recent_discord_messages(n: int = 10) -> list[dict]:
         return []
 
 
+# ─── public: count all discord messages ──────────────────────────────────────
+async def _discord_count_all() -> int:
+    """Coroutine to count ALL messages in the configured channel (oldest→newest)."""
+    if _discord_client is None:
+        return 0
+    try:
+        chan_id = int(os.getenv("DISCORD_CHANNEL_ID") or "0")
+    except Exception:
+        chan_id = 0
+    if not chan_id:
+        return 0
+    ch = _discord_client.get_channel(chan_id)
+    if ch is None:
+        try:
+            ch = await _discord_client.fetch_channel(chan_id)
+        except Exception:
+            return 0
+    total = 0
+    async for _ in ch.history(limit=None, oldest_first=True):
+        total += 1
+    return total
+
+
+def count_discord_messages() -> int:
+    """Sync wrapper returning the total message count."""
+    loop = _discord_loop
+    if loop is None:
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            return 0
+    fut = asyncio.run_coroutine_threadsafe(_discord_count_all(), loop)
+    try:
+        return int(fut.result(timeout=10))
+    except Exception:
+        return 0
+
+
+# ─── public: fetch arbitrary slice by (start_index, count) ───────────────────
+async def _discord_fetch_range(start_index: int, count: int) -> list[dict]:
+    """
+    Coroutine to fetch 'count' messages starting at 1-based index 'start_index'
+    (oldest→newest). Returns list of dicts: {author, text, timestamp}.
+    """
+    if _discord_client is None:
+        return []
+    try:
+        chan_id = int(os.getenv("DISCORD_CHANNEL_ID") or "0")
+    except Exception:
+        chan_id = 0
+    if not chan_id:
+        return []
+    ch = _discord_client.get_channel(chan_id)
+    if ch is None:
+        try:
+            ch = await _discord_client.fetch_channel(chan_id)
+        except Exception:
+            return []
+
+    start_index = max(1, int(start_index))
+    count = max(0, int(count))
+    if count == 0:
+        return []
+
+    out: list[dict] = []
+    idx = 0
+    async for m in ch.history(limit=None, oldest_first=True):
+        idx += 1
+        if idx < start_index:
+            continue
+        out.append({
+            "author": getattr(m.author, "display_name", str(m.author)),
+            "text": m.content,
+            "timestamp": m.created_at.isoformat(),
+        })
+        if len(out) >= count:
+            break
+    return out
+
+
+def fetch_discord_messages_slice(start_index: int, count: int) -> list[dict]:
+    """Sync wrapper for _discord_fetch_range(start_index, count)."""
+    loop = _discord_loop
+    if loop is None:
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            return []
+    fut = asyncio.run_coroutine_threadsafe(
+        _discord_fetch_range(int(start_index), int(count)), loop
+    )
+    try:
+        return fut.result(timeout=10)
+    except Exception:
+        return []
+
+
 def hsl_to_hex(h: int, s: float, l: float) -> str:
     r, g, b = colorsys.hls_to_rgb(h / 360.0, l, s)
     return "#%02x%02x%02x" % (int(r * 255), int(g * 255), int(b * 255))


### PR DESCRIPTION
## Summary
- add discord UI helpers to count all messages and fetch arbitrary slices
- expose new helpers through get_discord_message_count and get_discord_messages Fenra functions

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f92eb4d96c832d9297fcda11488309