### PR TITLE
Revamp function call UX and metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,5 +58,5 @@ CALL:list_functions()
 *~rename_agent("Old_Name","New_Name")~*
 CALL:rename_agent("Old_Name","New_Name")
 
-Why these constraints? Fenra extracts function-call spans strictly as `*~ ... ~*` and validates only that the characters touching the markers are non-whitespace before dispatching them via `fenra_functions.dispatch_expression(...)`. The Conductor also logs the function name and result back into the message stream. The CALL echo makes the exact call visible too.
+Why these constraints? Fenra extracts function-call spans strictly as `*~ ... ~*` and validates only that the characters touching the markers are non-whitespace before dispatching them via `fenra_functions.dispatch_expression(...)`. The runtime records each executed call in the Function Calls tab and appends a summary note to the agent reply, so the explicit `CALL:` echo keeps the exact invocation visible to humans reviewing the transcript.
 ```

--- a/conductor.py
+++ b/conductor.py
@@ -878,9 +878,12 @@ def step_agent(agent_name: str) -> Optional[str]:
             )
             calls_log.append((fn_name, params_display, result))
         if calls_log:
-            reply = reply.rstrip("\n")
-            notice = f"(Executed {len(calls_log)} function call(s). See the \"Function Calls\" tab.)"
-            reply = f"{reply}\n\n{notice}" if reply else notice
+            # Inline only the results (no names, no timestamps) into the agent-visible text.
+            results = "\n\n".join(
+                (res if isinstance(res, str) else json.dumps(res, ensure_ascii=False))
+                for _, _, res in calls_log
+            )
+            reply = f"{reply.rstrip()}\n\n{results}" if reply else results
 
     cls = CLASSES[agent["agent_class"]]
     groups_target = list(agent.get("groups_out") or agent.get("groups_in") or [])

--- a/conductor.py
+++ b/conductor.py
@@ -868,17 +868,19 @@ def step_agent(agent_name: str) -> Optional[str]:
         return nxt["name"] if nxt else None
     # Execute any Fenra function calls emitted by the agent as *~...~* blocks.
     commands = _extract_pwsh_commands(reply)
+    calls_log: list[tuple[str, str, str]] = []
     if commands:
         for cmd in commands:
             expr = (cmd or "").strip()
-            fn_name, _found, result = fenra_functions.dispatch_expression(expr)
-            if UI is not None and hasattr(UI, "append_ps"):
-                try:
-                    UI.append_ps(f"Function called: {fn_name}")
-                    UI.append_ps(f"Function result: {result}")
-                except Exception:
-                    logger.exception("UI append_ps failed for function dispatch")
-            reply += f"\nFunction called: {fn_name}\nFunction result: {result}\n"
+            fn_name, _found, result, params_string = fenra_functions.dispatch_expression(expr)
+            params_display = (
+                params_string if params_string and params_string.strip() else '""'
+            )
+            calls_log.append((fn_name, params_display, result))
+        if calls_log:
+            reply = reply.rstrip("\n")
+            notice = f"(Executed {len(calls_log)} function call(s). See the \"Function Calls\" tab.)"
+            reply = f"{reply}\n\n{notice}" if reply else notice
 
     cls = CLASSES[agent["agent_class"]]
     groups_target = list(agent.get("groups_out") or agent.get("groups_in") or [])
@@ -895,6 +897,12 @@ def step_agent(agent_name: str) -> Optional[str]:
     msgs.append(entry)
     _save_messages_to_humans(msgs)
     _append_human_log(entry)
+
+    if calls_log and UI is not None and hasattr(UI, "append_function_calls_block"):
+        try:
+            UI.append_function_calls_block(agent["name"], timestamp, calls_log)
+        except Exception:
+            logger.exception("UI append_function_calls_block failed")
 
     # Only post to Discord if the class (or agent) opts in AND the webhook is configured.
     should_post = bool(cls.get("outputs_to_discord") or agent.get("outputs_to_discord"))

--- a/fenra_functions.py
+++ b/fenra_functions.py
@@ -252,7 +252,8 @@ def get_discord_messages(*args) -> str:
     if len(args) == 0:
         try:
             items = fe.fetch_recent_discord_messages(1) or []
-            return _fmt(items[:1])
+            body = _fmt(items[:1])
+            return f"The following is the most recent Discord message:\n{body}"
         except Exception as e:
             return f"(error) {type(e).__name__}: {e}"
 
@@ -264,7 +265,8 @@ def get_discord_messages(*args) -> str:
             return "(error) ValueError: expected integer 'n'"
         try:
             items = fe.fetch_recent_discord_messages(n) or []
-            return _fmt(items)
+            body = _fmt(items)
+            return f"The following are the {n} most recent Discord messages:\n{body}"
         except Exception as e:
             return f"(error) {type(e).__name__}: {e}"
 
@@ -279,7 +281,12 @@ def get_discord_messages(*args) -> str:
             items = fe.fetch_recent_discord_messages(m + n) or []
             # items are newest→older; drop the newest M, keep next N
             sliced = items[m:m + n]
-            return _fmt(sliced)
+            body = _fmt(sliced)
+            return (
+                "The following are the {n} requested messages, end at the {m}th most recent message:\n"
+                .format(n=n, m=m)
+                + body
+            )
         except Exception as e:
             return f"(error) {type(e).__name__}: {e}"
 
@@ -540,7 +547,10 @@ def list_agents() -> str:
         except Exception:
             pass
     names = sorted([a.get("name") for a in getattr(conductor, "AGENTS", []) if a.get("name")])
-    return "\n".join(names) if names else "(no agents loaded)"
+    header = "The following agents currently exist."
+    if names:
+        return header + "\n" + "\n".join(names)
+    return header + "\n(no agents loaded)"
 
 
 register_details(

--- a/fenra_functions.py
+++ b/fenra_functions.py
@@ -88,15 +88,33 @@ def dispatch_expression(expr: str) -> tuple[str, bool, str, str]:
         if "(" in call_str and call_str.endswith(")"):
             params_string = call_str[call_str.find("(") + 1 : call_str.rfind(")")]
     except Exception:
-        return (guessed_name, False, "Function does not exist.", "")
+        name_display = guessed_name or "<unknown>"
+        return (
+            guessed_name,
+            False,
+            f"Function {name_display} does not exist.",
+            "",
+        )
 
     entry = _REGISTRY.get(name)
     if not entry:
-        return (name, False, "Function does not exist.", params_string)
+        name_display = name or "<unknown>"
+        return (
+            name,
+            False,
+            f"Function {name_display} does not exist.",
+            params_string,
+        )
 
     func = entry.get("func")
     if func is None:
-        return (name, False, "Function does not exist.", params_string)
+        name_display = name or "<unknown>"
+        return (
+            name,
+            False,
+            f"Function {name_display} does not exist.",
+            params_string,
+        )
     try:
         res = func(*args, **kwargs)
         result = "(No Output)" if res is None else str(res)

--- a/fenra_functions.py
+++ b/fenra_functions.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
-from typing import Callable, Dict, Tuple, Any
+
+from typing import Callable, Dict, Any, List
 import ast
 import subprocess
 import sys
 import shutil
-import re
 import json
 from copy import deepcopy
 
@@ -14,24 +14,38 @@ from copy import deepcopy
 # Function registry and API
 # ---------------------------
 
-_REGISTRY: Dict[str, tuple[Callable[..., str], str]] = {}
+_REGISTRY: Dict[str, Dict[str, Any]] = {}
 
 
 def register(name: str, description: str):
     """Decorator to register a callable Fenra function with a human-readable description."""
 
-    def _wrap(func: Callable[..., str]):
-        _REGISTRY[name] = (func, description)
+    def _wrap(func: Callable[..., Any]):
+        entry = _REGISTRY.get(name, {})
+        entry.update({"func": func, "description": description})
+        entry.setdefault("forms", [])
+        _REGISTRY[name] = entry
         return func
 
     return _wrap
 
 
-def _like_to_regex(pattern: str) -> re.Pattern:
-    """Translate a % wildcard pattern to a case-insensitive regex."""
-    escaped = re.escape(pattern)
-    rx = ".*" if not escaped else escaped.replace(r"\%", ".*")
-    return re.compile(rx, re.IGNORECASE)
+def register_details(name: str, forms: List[Dict[str, str]]) -> None:
+    """Register rich metadata for a Fenra function."""
+
+    normalized: list[dict[str, str]] = []
+    for form in forms or []:
+        normalized.append(
+            {
+                "parameters": str(form.get("parameters", "")),
+                "usage": str(form.get("usage", "")),
+                "returns": str(form.get("returns", "")),
+            }
+        )
+
+    entry = _REGISTRY.setdefault(name, {"forms": []})
+    entry.setdefault("description", "")
+    entry["forms"] = normalized
 
 
 def _literalize(node: ast.AST) -> Any:
@@ -58,7 +72,7 @@ def _parse_call(expr: str) -> tuple[str, list[Any], dict[str, Any]]:
     return fn_name, args, kwargs
 
 
-def dispatch_expression(expr: str) -> tuple[str, bool, str]:
+def dispatch_expression(expr: str) -> tuple[str, bool, str, str]:
     """
     Dispatch a Fenra function expression found inside *~...~*.
     Returns (function_name_or_guess, found, result_string).
@@ -66,22 +80,29 @@ def dispatch_expression(expr: str) -> tuple[str, bool, str]:
     - found=True for executed or error-returning calls (errors are returned as strings).
     """
     guessed_name = expr.strip()
+    params_string = ""
     try:
         name, args, kwargs = _parse_call(expr)
         guessed_name = name
+        call_str = expr.strip()
+        if "(" in call_str and call_str.endswith(")"):
+            params_string = call_str[call_str.find("(") + 1 : call_str.rfind(")")]
     except Exception:
-        return (guessed_name, False, "Function does not exist.")
+        return (guessed_name, False, "Function does not exist.", "")
 
     entry = _REGISTRY.get(name)
     if not entry:
-        return (name, False, "Function does not exist.")
+        return (name, False, "Function does not exist.", params_string)
 
-    func, _desc = entry
+    func = entry.get("func")
+    if func is None:
+        return (name, False, "Function does not exist.", params_string)
     try:
         res = func(*args, **kwargs)
-        return (name, True, "" if res is None else str(res))
+        result = "(No Output)" if res is None else str(res)
+        return (name, True, result, params_string)
     except Exception as e:
-        return (name, True, f"(error) {type(e).__name__}: {e}")
+        return (name, True, f"(error) {type(e).__name__}: {e}", params_string)
 
 
 # --------------------------------
@@ -89,28 +110,74 @@ def dispatch_expression(expr: str) -> tuple[str, bool, str]:
 # --------------------------------
 
 
-@register("list_functions", "List available Fenra functions; supports % wildcard on name/description.")
+@register("list_functions", "List available Fenra functions.")
 def list_functions(search: str = "") -> str:
-    """
-    Return a newline-separated list of 'name: description'.
-    If search is provided, use % as wildcard and match name/description (case-insensitive).
-    Always includes this function in the registry.
-    """
-    _REGISTRY.setdefault(
-        "list_functions",
-        (list_functions, "List available Fenra functions; supports % wildcard on name/description."),
-    )
+    """Return the structured catalog of Fenra functions, optionally filtered by search."""
 
-    items = []
-    if search:
-        rx = _like_to_regex(search)
-        for name, (_fn, desc) in _REGISTRY.items():
-            if rx.search(name) or rx.search(desc or ""):
-                items.append(f"{name}: {desc}")
-    else:
-        for name in sorted(_REGISTRY):
-            items.append(f"{name}: {_REGISTRY[name][1]}")
-    return "\n".join(items) if items else "(no matching functions)"
+    entry = _REGISTRY.setdefault(
+        "list_functions",
+        {"func": list_functions, "description": "List available Fenra functions.", "forms": []},
+    )
+    if not entry.get("forms"):
+        register_details(
+            "list_functions",
+            [
+                {
+                    "parameters": 'search: str=""',
+                    "usage": "Return the catalog of available Fenra functions or the subset matching the search string.",
+                    "returns": "A formatted list of functions, their usage forms, and return values.",
+                }
+            ],
+        )
+
+    def _format_entry(name: str, info: Dict[str, Any]) -> str:
+        forms = info.get("forms") or []
+        if not forms:
+            forms = [
+                {
+                    "parameters": "",
+                    "usage": info.get("description", ""),
+                    "returns": "(No Output)",
+                }
+            ]
+
+        lines: list[str] = [name, "Usage:"]
+        for idx, form in enumerate(forms):
+            params = form.get("parameters", "")
+            params_display = params if params else ""
+            call_line = f"\t{name}({params_display})" if params_display else f"\t{name}()"
+            lines.append(f"{call_line}:")
+            lines.append(f"\t\t{form.get('usage', '')}")
+            lines.append("")
+            returns_text = form.get("returns", "") or "(No Output)"
+            lines.append(f"\t\tReturns: {returns_text}")
+            if idx != len(forms) - 1:
+                lines.append("")
+        return "\n".join(lines)
+
+    search_text = (search or "").strip().lower()
+    formatted: list[str] = []
+    for name in sorted(_REGISTRY):
+        info = _REGISTRY[name]
+        if search_text:
+            haystacks = [name.lower(), str(info.get("description", "")).lower()]
+            for form in info.get("forms") or []:
+                haystacks.extend(
+                    [
+                        str(form.get("parameters", "")).lower(),
+                        str(form.get("usage", "")).lower(),
+                        str(form.get("returns", "")).lower(),
+                    ]
+                )
+            if not any(search_text in hay for hay in haystacks):
+                continue
+        formatted.append(_format_entry(name, info))
+
+    if not formatted:
+        return "(no matching functions)"
+
+    body = "\n\n".join(formatted)
+    return f"You have access to the following functions:\n\n{body}"
 
 
 @register("announce_self", "Announce the name of the current agent.")
@@ -122,6 +189,18 @@ def announce_self() -> str:
     if not isinstance(name, str) or not name:
         name = "unknown"
     return f"The agent who ran this function is named '{name}'"
+
+
+register_details(
+    "announce_self",
+    [
+        {
+            "parameters": "",
+            "usage": "Return the name of the agent currently executing this function.",
+            "returns": "The calling agent's name as text.",
+        }
+    ],
+)
 
 
 @register(
@@ -189,6 +268,28 @@ def get_discord_messages(*args) -> str:
     return "(error) ValueError: get_discord_messages accepts 0, 1, or 2 arguments"
 
 
+register_details(
+    "get_discord_messages",
+    [
+        {
+            "parameters": "",
+            "usage": "Return the most recent Discord message.",
+            "returns": "The latest Discord message text or an error description.",
+        },
+        {
+            "parameters": "n: int",
+            "usage": "Return the last n Discord messages from newest to oldest.",
+            "returns": "A newline-separated list of Discord messages or an error description.",
+        },
+        {
+            "parameters": "m: int, n: int",
+            "usage": "Skip the most recent m Discord messages, then return the next n messages (newest to older).",
+            "returns": "A newline-separated list of Discord messages or an error description.",
+        },
+    ],
+)
+
+
 @register("fenra_powershell", "Execute a PowerShell command string and return its output.")
 def fenra_powershell(command: str) -> str:
     """
@@ -216,6 +317,18 @@ def fenra_powershell(command: str) -> str:
         return combined.strip()
     except Exception as e:
         return f"(error) {type(e).__name__}: {e}"
+
+
+register_details(
+    "fenra_powershell",
+    [
+        {
+            "parameters": "command: str",
+            "usage": "Execute the provided PowerShell command string and capture its output.",
+            "returns": "The combined stdout/stderr from PowerShell or an error message. Returns (No Output) when the command produced no text.",
+        }
+    ],
+)
 
 
 @register("duplicate_self", "Duplicate the current agent as <name>-dup and save/refresh.")
@@ -287,6 +400,18 @@ def duplicate_self() -> str:
         pass
 
     return f"Duplicated {base} → {name}"
+
+
+register_details(
+    "duplicate_self",
+    [
+        {
+            "parameters": "",
+            "usage": "Clone the calling agent with a '-dup' suffix (adding a number if needed) and refresh runtime state.",
+            "returns": "Confirmation of the original and duplicated agent names.",
+        }
+    ],
+)
 
 
 @register(
@@ -400,6 +525,18 @@ def list_agents() -> str:
     return "\n".join(names) if names else "(no agents loaded)"
 
 
+register_details(
+    "list_agents",
+    [
+        {
+            "parameters": "",
+            "usage": "Return the names of all currently loaded agents, one per line.",
+            "returns": "A newline-separated list of agent names or '(no agents loaded)'.",
+        }
+    ],
+)
+
+
 @register(
     "call_agent",
     "Set which agent runs next. Usage: call_agent() to re-run the caller, or call_agent(\"Agent Name\")."
@@ -433,4 +570,21 @@ def call_agent(*args) -> str:
 
     conductor.STATE["force_next_agent"] = target
     return f"Next agent set to: {target}"
+
+
+register_details(
+    "call_agent",
+    [
+        {
+            "parameters": "",
+            "usage": "Schedule the current agent to take another turn immediately after this one.",
+            "returns": "Confirmation of the next agent to run or an error message.",
+        },
+        {
+            "parameters": "name: str",
+            "usage": "Select the named agent to run next.",
+            "returns": "Confirmation of the next agent to run or an error message.",
+        },
+    ],
+)
 

--- a/fenra_ui.py
+++ b/fenra_ui.py
@@ -585,18 +585,8 @@ class FenraUI:
         thoughts_tab = ttk.Frame(self.notebook)
         self.notebook.add(thoughts_tab, text="Internal Thoughts")
 
-        paned = ttk.Panedwindow(thoughts_tab, orient=tk.HORIZONTAL)
-        paned.pack(fill=tk.BOTH, expand=True)
-
-        thought_frame = ttk.Frame(paned)
-        event_frame = ttk.Frame(paned)
-        paned.add(thought_frame, weight=1)
-        paned.add(event_frame, weight=1)
-
-        self.thought_stream = scrolledtext.ScrolledText(thought_frame, state="disabled")
+        self.thought_stream = scrolledtext.ScrolledText(thoughts_tab, state="disabled")
         self.thought_stream.pack(fill=tk.BOTH, expand=True)
-
-        ttk.Label(event_frame, text="PowerShell Console").pack(anchor="w", padx=4, pady=(0, 2))
 
         try:
             console_font = tkfont.nametofont("TkFixedFont")
@@ -604,15 +594,19 @@ class FenraUI:
             console_font = tkfont.Font(family="Consolas", size=10)
         self._console_font = console_font
 
-        self.events_stream = scrolledtext.ScrolledText(
-            event_frame,
+        function_calls_tab = ttk.Frame(self.notebook)
+        self.notebook.add(function_calls_tab, text="Function Calls")
+
+        self.function_calls_stream = scrolledtext.ScrolledText(
+            function_calls_tab,
             state="disabled",
             wrap=tk.NONE,
             font=self._console_font,
         )
-        self.events_stream.pack(fill=tk.BOTH, expand=True)
+        self.function_calls_stream.pack(fill=tk.BOTH, expand=True)
 
         # Backward compatibility
+        self.events_stream = self.function_calls_stream
         self.output = self.thought_stream
 
         self.base_timeout = self.global_config.get("watchdog_timeout", 900)
@@ -1074,12 +1068,56 @@ class FenraUI:
         self._threadsafe(_append)
         logger.debug("Exiting append_event")
 
+    def append_function_calls_block(
+        self, agent: str, timestamp: str, calls: list[tuple[str, str, str]]
+    ) -> None:
+        logger.debug(
+            "Entering append_function_calls_block agent=%s timestamp=%s calls=%s",
+            agent,
+            timestamp,
+            calls,
+        )
+        if not calls:
+            logger.debug("No calls provided; exiting append_function_calls_block")
+            return
+
+        def _append():
+            lines: list[str] = [f"-----{agent} {timestamp}-----"]
+            total = len(calls)
+            for idx, (fn_name, params_text, result_text) in enumerate(calls):
+                params_render = (
+                    params_text if params_text and params_text.strip() else '""'
+                )
+                result_render = "(No Output)" if result_text is None else str(result_text)
+                lines.append(f"{fn_name}({params_render}):")
+                lines.append(result_render)
+                if idx != total - 1:
+                    lines.append("")
+                    lines.append("")
+            block = "\n".join(lines)
+            if not block.endswith("\n"):
+                block += "\n"
+            self._append_text(self.function_calls_stream, block)
+
+        self._threadsafe(_append)
+        logger.debug("Exiting append_function_calls_block")
+
     def append_ps(self, line: str) -> None:
         logger.debug("Entering append_ps line=%s", line)
 
+        stripped = (line or "").strip()
+        if not stripped:
+            logger.debug("append_ps received empty line; exiting")
+            return
+
+        legacy_prefixes = ("Function called:", "Function result:")
+        if not stripped.startswith(legacy_prefixes):
+            logger.debug("append_ps ignoring non-legacy line")
+            return
+
         def _append():
             txt = line if line.endswith("\n") else f"{line}\n"
-            self._append_text(self.events_stream, txt)
+            self._append_text(self.function_calls_stream, txt)
 
         self._threadsafe(_append)
         logger.debug("Exiting append_ps")
@@ -1088,9 +1126,9 @@ class FenraUI:
         logger.debug("Entering clear_ps")
 
         def _do():
-            self.events_stream.configure(state="normal")
-            self.events_stream.delete("1.0", tk.END)
-            self.events_stream.configure(state="disabled")
+            self.function_calls_stream.configure(state="normal")
+            self.function_calls_stream.delete("1.0", tk.END)
+            self.function_calls_stream.configure(state="disabled")
 
         self._threadsafe(_do)
         logger.debug("Exiting clear_ps")


### PR DESCRIPTION
## Summary
- replace the PowerShell console with a top-level Function Calls tab and add a renderer for structured call blocks
- collect function call results per agent turn, append a concise notice to replies, and forward the calls to the new tab
- enrich the Fenra function registry with form metadata, improved list_functions search output, and standardized `(No Output)` handling
- update documentation to describe the new Function Calls logging behavior

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68fa2c50c364832dbfb4441700aa00c6