### PR TITLE
Add speak_to_discord Fenra function for manual Discord posts

### DIFF
--- a/conductor.py
+++ b/conductor.py
@@ -866,6 +866,15 @@ def step_agent(agent_name: str) -> Optional[str]:
         logger.exception("Generation failed for %s: %s", agent["name"], exc)
         nxt = select_next_agent(agent_name)
         return nxt["name"] if nxt else None
+    # Make the agent's *visible* output (with Fenra call markup stripped) available to Fenra functions.
+    try:
+        raw = reply or ""
+        visible = re.sub(r"\*~.*?~\*", "", raw, flags=re.DOTALL).strip()
+    except Exception:
+        visible = (reply or "").strip()
+
+    # Expose to fenra_functions via the conductor module namespace
+    globals()["_LAST_VISIBLE_OUTPUT"] = visible
     # Execute any Fenra function calls emitted by the agent as *~...~* blocks.
     commands = _extract_pwsh_commands(reply)
     calls_log: list[tuple[str, str, str]] = []

--- a/fenra_functions.py
+++ b/fenra_functions.py
@@ -766,3 +766,47 @@ register_details(
     ],
 )
 
+@register("speak_to_discord", "Post the agent's visible output to Discord and return that text.")
+def speak_to_discord(*args, **kwargs) -> str:
+    import importlib, os
+
+    # Enforce zero-arg contract
+    if args:
+        return "(error) ValueError: unexpected positional arguments"
+    if kwargs:
+        key = next(iter(kwargs))
+        return f"(error) ValueError: unexpected keyword '{key}'"
+
+    # Fetch the message the user actually sees (with *~...~* stripped)
+    conductor = importlib.import_module("conductor")
+    text = getattr(conductor, "_LAST_VISIBLE_OUTPUT", "")
+    text = (text or "").strip()
+    if not text:
+        return "(no output)"
+
+    # Post via existing webhook helper if configured
+    webhook = os.getenv("DISCORD_WEBHOOK_URL")
+    post = getattr(conductor, "post_to_discord_via_webhook", None)
+    if webhook and callable(post):
+        try:
+            post(text)
+        except Exception as e:
+            return f"(error) Discord post failed: {type(e).__name__}: {e}"
+    else:
+        return "(error) Discord webhook not configured"
+
+    # Also return the visible text as the function output
+    return text
+
+
+register_details(
+    "speak_to_discord",
+    [
+        {
+            "parameters": "",
+            "usage": "Send the agent's visible output (with any *~...~* removed) to Discord. Place *~speak_to_discord()~* at the end of your message.",
+            "returns": "The exact text that was sent to Discord, or an error description.",
+        }
+    ],
+)
+


### PR DESCRIPTION
## Summary
- expose the agent's latest visible output on the conductor module so Fenra functions can access it
- add the speak_to_discord Fenra function to post the visible output via the configured Discord webhook on demand

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fac21811d0832dbb5d78ae69ae93f1