### PR TITLE
Add header to documentation listing

### DIFF
--- a/fenra_functions.py
+++ b/fenra_functions.py
@@ -711,7 +711,8 @@ def read_documentation(*args, **kwargs) -> str:
         return f"(error) ValueError: unexpected keyword '{key}'"
 
     if filename is None:
-        return _list_files(DOC_DIR)
+        files = _list_files(DOC_DIR)
+        return "The following documentation is available:\n" + files
 
     path = _safe_path(DOC_DIR, filename)
     try:


### PR DESCRIPTION
## Summary
- add a descriptive header when listing documentation files

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68fbb8bdd514832d95623704e7565d8f