### PR TITLE
Add diary directory tools and tagging

### DIFF
--- a/config_loader.py
+++ b/config_loader.py
@@ -5,7 +5,7 @@ import json
 import os
 
 from pathlib import Path
-from typing import Dict
+from typing import Any, Dict
 from config import CONF_DIR
 
 
@@ -206,3 +206,33 @@ def save_agents(agents: list[dict], path: str = _conf_path('agents.json')) -> No
 
 def save_state(state: dict, path: str = _conf_path('state.json')) -> None:
     _atomic_write(path, state)
+
+
+def get_path(key: str, default: str | Path | None = None) -> Path | None:
+    """Resolve a filesystem path from the globals configuration."""
+
+    if not key:
+        raise ValueError("key must be provided")
+
+    data: Any = try_load_globals()
+    for part in key.split('.'):
+        if isinstance(data, dict) and part in data:
+            data = data[part]
+        else:
+            data = None
+            break
+
+    if data is None:
+        data = default
+
+    if data is None:
+        return None
+
+    if isinstance(data, Path):
+        path = data
+    elif isinstance(data, str):
+        path = Path(data)
+    else:
+        raise TypeError(f"Configuration value for {key!r} must be a string path.")
+
+    return path.expanduser()

--- a/diary_tags.py
+++ b/diary_tags.py
@@ -1,0 +1,331 @@
+"""Diary directory management and tagging restricted to the diary root."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional
+
+import json
+import os
+import shutil
+import time
+
+
+@dataclass(frozen=True)
+class DiaryPaths:
+    """Resolved paths used for diary operations."""
+
+    diary_root: Path
+    documentation_root: Optional[Path] = None
+
+
+# -------- Path guards --------
+def _resolve_in_diary(paths: DiaryPaths, rel: str | Path) -> Path:
+    """Resolve a diary-relative path and ensure it never escapes the diary root."""
+
+    rel_path = Path(rel)
+    if rel_path.is_absolute():
+        raise PermissionError("Absolute paths are not allowed.")
+
+    diary_root = paths.diary_root.resolve()
+    target = (paths.diary_root / rel_path).resolve()
+
+    if paths.documentation_root is not None:
+        doc_root = paths.documentation_root.resolve()
+        try:
+            target.relative_to(doc_root)
+        except ValueError:
+            pass
+        else:
+            raise PermissionError("Writes to documentation are not allowed.")
+
+    try:
+        target.relative_to(diary_root)
+    except ValueError as exc:
+        raise PermissionError("Path escapes the diary root.") from exc
+
+    return target
+
+
+def _ensure_dir(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+
+
+def _atomic_write_json(target: Path, payload: dict) -> None:
+    tmp = target.with_suffix(target.suffix + f".tmp-{int(time.time() * 1000)}")
+    _ensure_dir(tmp.parent)
+    with tmp.open("w", encoding="utf-8") as handle:
+        json.dump(payload, handle, ensure_ascii=False, indent=2, sort_keys=True)
+    os.replace(tmp, target)
+
+
+# -------- Tag sidecar helpers --------
+def sidecar_path(file_path: Path) -> Path:
+    return file_path.with_suffix(file_path.suffix + ".tags.json")
+
+
+def _normalize_tags(tags: Iterable[str]) -> List[str]:
+    seen: Dict[str, str] = {}
+    for tag in tags:
+        if not isinstance(tag, str):
+            continue
+        cleaned = tag.strip()
+        if not cleaned:
+            continue
+        lower = cleaned.lower()
+        if lower not in seen:
+            seen[lower] = cleaned
+    return sorted(seen.values(), key=str.lower)
+
+
+def read_tags(file_path: Path) -> List[str]:
+    sc_path = sidecar_path(file_path)
+    if not sc_path.exists():
+        return []
+    try:
+        data = json.loads(sc_path.read_text(encoding="utf-8"))
+    except Exception:
+        return []
+    tags = data.get("tags", [])
+    return _normalize_tags(tags)
+
+
+def write_tags(file_path: Path, tags: Iterable[str]) -> List[str]:
+    ordered = _normalize_tags(tags)
+    sidecar = sidecar_path(file_path)
+    _atomic_write_json(sidecar, {"tags": ordered})
+    return ordered
+
+
+# -------- Index helpers --------
+def _index_file_map(paths: DiaryPaths) -> Path:
+    fenra_dir = paths.diary_root / ".fenra"
+    _ensure_dir(fenra_dir)
+    return fenra_dir / "tags_index.json"
+
+
+def load_index(paths: DiaryPaths) -> Dict[str, List[str]]:
+    index_path = _index_file_map(paths)
+    if not index_path.exists():
+        return {}
+    try:
+        data = json.loads(index_path.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+    files = data.get("files", {})
+    normalized: Dict[str, List[str]] = {}
+    if isinstance(files, dict):
+        for rel, tags in files.items():
+            if not isinstance(rel, str):
+                continue
+            normalized_tags = _normalize_tags(tags if isinstance(tags, list) else [])
+            if normalized_tags:
+                normalized[rel] = normalized_tags
+    return normalized
+
+
+def save_index(paths: DiaryPaths, files_map: Dict[str, List[str]]) -> None:
+    payload_files: Dict[str, List[str]] = {}
+    for rel, tags in files_map.items():
+        normalized_tags = _normalize_tags(tags)
+        if normalized_tags:
+            payload_files[rel] = normalized_tags
+
+    payload = {
+        "version": 1,
+        "updated_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "files": payload_files,
+    }
+    _atomic_write_json(_index_file_map(paths), payload)
+
+
+def reindex(paths: DiaryPaths) -> int:
+    files_map: Dict[str, List[str]] = {}
+    diary_root = paths.diary_root.resolve()
+    for item in diary_root.rglob("*"):
+        if not item.is_file():
+            continue
+        try:
+            rel_path = item.relative_to(diary_root)
+        except ValueError:
+            continue
+        if rel_path.parts and rel_path.parts[0] == ".fenra":
+            continue
+        if item.name.endswith(".tags.json"):
+            continue
+        tags = read_tags(item)
+        if tags:
+            files_map[rel_path.as_posix()] = tags
+    save_index(paths, files_map)
+    return len(files_map)
+
+
+# -------- Directory operations --------
+def list_tree(paths: DiaryPaths, rel_dir: str = ".") -> Dict[str, object]:
+    base = _resolve_in_diary(paths, rel_dir)
+    rel_display = Path(rel_dir)
+    result: Dict[str, object] = {"path": str(rel_display), "dirs": [], "files": []}
+
+    if not base.exists():
+        return result  # type: ignore[return-value]
+
+    dirs: List[str] = []
+    files: List[str] = []
+    for child in sorted(base.iterdir(), key=lambda p: (p.is_file(), p.name.lower())):
+        if child.name.endswith(".tags.json"):
+            continue
+        if child.is_dir():
+            if child.name == ".fenra":
+                continue
+            dirs.append(child.name)
+        elif child.is_file():
+            files.append(child.name)
+
+    result["dirs"] = dirs
+    result["files"] = files
+    return result
+
+
+def mkdir(paths: DiaryPaths, rel_dir: str) -> str:
+    directory = _resolve_in_diary(paths, rel_dir)
+    _ensure_dir(directory)
+    return directory.relative_to(paths.diary_root.resolve()).as_posix()
+
+
+def move(paths: DiaryPaths, rel_src: str, rel_dst: str, overwrite: bool = False) -> str:
+    src = _resolve_in_diary(paths, rel_src)
+    if not src.exists():
+        raise FileNotFoundError(f"Source not found: {rel_src}")
+
+    dst = _resolve_in_diary(paths, rel_dst)
+
+    if dst.exists():
+        if not overwrite:
+            raise FileExistsError(f"Destination exists: {rel_dst}")
+        if dst.is_dir():
+            shutil.rmtree(dst)
+        else:
+            dst.unlink()
+
+    _ensure_dir(dst.parent)
+    shutil.move(str(src), str(dst))
+
+    if dst.is_file():
+        src_sidecar = sidecar_path(src)
+        if src_sidecar.exists():
+            dst_sidecar = sidecar_path(dst)
+            _ensure_dir(dst_sidecar.parent)
+            shutil.move(str(src_sidecar), str(dst_sidecar))
+
+    reindex(paths)
+    return dst.relative_to(paths.diary_root.resolve()).as_posix()
+
+
+def remove(paths: DiaryPaths, rel_path: str) -> bool:
+    target = _resolve_in_diary(paths, rel_path)
+    if not target.exists():
+        return False
+
+    if target.is_dir():
+        for sidecar in target.rglob("*.tags.json"):
+            try:
+                sidecar.unlink()
+            except FileNotFoundError:
+                pass
+        shutil.rmtree(target)
+    else:
+        try:
+            target.unlink()
+        except FileNotFoundError:
+            pass
+        sidecar = sidecar_path(target)
+        try:
+            sidecar.unlink()
+        except FileNotFoundError:
+            pass
+
+    reindex(paths)
+    return True
+
+
+# -------- Tag operations --------
+def get_file_tags(paths: DiaryPaths, rel_file: str) -> List[str]:
+    file_path = _resolve_in_diary(paths, rel_file)
+    if not file_path.exists() or not file_path.is_file():
+        raise FileNotFoundError(rel_file)
+    return read_tags(file_path)
+
+
+def add_file_tags(paths: DiaryPaths, rel_file: str, tags: Iterable[str]) -> List[str]:
+    file_path = _resolve_in_diary(paths, rel_file)
+    if not file_path.exists() or not file_path.is_file():
+        raise FileNotFoundError(rel_file)
+
+    existing = read_tags(file_path)
+    combined = existing + [t for t in tags if isinstance(t, str)]
+    final = write_tags(file_path, combined)
+
+    index = load_index(paths)
+    rel_key = file_path.relative_to(paths.diary_root.resolve()).as_posix()
+    if final:
+        index[rel_key] = final
+    else:
+        index.pop(rel_key, None)
+    save_index(paths, index)
+    return final
+
+
+def remove_file_tags(paths: DiaryPaths, rel_file: str, tags: Iterable[str]) -> List[str]:
+    file_path = _resolve_in_diary(paths, rel_file)
+    if not file_path.exists() or not file_path.is_file():
+        raise FileNotFoundError(rel_file)
+
+    existing = read_tags(file_path)
+    removals = {t.strip().lower() for t in tags if isinstance(t, str) and t.strip()}
+    remaining = [tag for tag in existing if tag.lower() not in removals]
+    final = write_tags(file_path, remaining)
+
+    index = load_index(paths)
+    rel_key = file_path.relative_to(paths.diary_root.resolve()).as_posix()
+    if final:
+        index[rel_key] = final
+    else:
+        index.pop(rel_key, None)
+    save_index(paths, index)
+    return final
+
+
+def set_file_tags(paths: DiaryPaths, rel_file: str, tags: Iterable[str]) -> List[str]:
+    file_path = _resolve_in_diary(paths, rel_file)
+    if not file_path.exists() or not file_path.is_file():
+        raise FileNotFoundError(rel_file)
+
+    final = write_tags(file_path, tags)
+    index = load_index(paths)
+    rel_key = file_path.relative_to(paths.diary_root.resolve()).as_posix()
+    if final:
+        index[rel_key] = final
+    else:
+        index.pop(rel_key, None)
+    save_index(paths, index)
+    return final
+
+
+def search_by_tags(paths: DiaryPaths, include: Iterable[str], exclude: Iterable[str] = ()) -> List[str]:
+    include_set = {t.strip().lower() for t in include if isinstance(t, str) and t.strip()}
+    exclude_set = {t.strip().lower() for t in exclude if isinstance(t, str) and t.strip()}
+
+    index = load_index(paths)
+    matches: List[str] = []
+    for rel, tags in index.items():
+        lower_tags = {t.lower() for t in tags}
+        if include_set and not include_set.issubset(lower_tags):
+            continue
+        if exclude_set and lower_tags & exclude_set:
+            continue
+        matches.append(rel)
+
+    matches.sort()
+    return matches
+

--- a/fenra_functions.py
+++ b/fenra_functions.py
@@ -8,7 +8,22 @@ import shutil
 import json
 import os
 from copy import deepcopy
+from pathlib import Path
 
+from config_loader import get_path
+from diary_tags import (
+    DiaryPaths,
+    add_file_tags,
+    get_file_tags,
+    list_tree as diary_list_tree,
+    mkdir as diary_mkdir,
+    move as diary_move,
+    reindex as diary_reindex,
+    remove as diary_remove,
+    remove_file_tags,
+    search_by_tags as diary_search_by_tags,
+    set_file_tags,
+)
 
 
 # ---------------------------
@@ -109,6 +124,21 @@ DIARY_DIR = "fenra_diary"
 
 def _ensure_dir(path: str) -> None:
     os.makedirs(path, exist_ok=True)
+
+
+def _diary_paths() -> DiaryPaths:
+    diary_default = Path.home() / DIARY_DIR
+    diary_root = get_path("paths.diary", default=diary_default)
+    if diary_root is None:
+        diary_root = diary_default
+    diary_root = Path(diary_root).expanduser()
+    diary_root.mkdir(parents=True, exist_ok=True)
+
+    documentation_root = get_path("paths.documentation", default=None)
+    if documentation_root is not None:
+        documentation_root = Path(documentation_root).expanduser()
+
+    return DiaryPaths(diary_root=diary_root, documentation_root=documentation_root)
 
 
 def _sanitize_filename(name: str) -> str:
@@ -926,6 +956,257 @@ register_details(
         },
     ],
 )
+
+
+@register("diary.list_tree", "List directories and files within the diary root.")
+def diary_fn_list_tree(*args, **kwargs) -> str:
+    args = list(args)
+    kwargs = dict(kwargs)
+    try:
+        rel_dir = _get_param(args, kwargs, "rel_dir", default=".", cast=str)
+    except ValueError as e:
+        return f"(error) ValueError: {e}"
+
+    if args:
+        return "(error) ValueError: unexpected positional arguments"
+    if kwargs:
+        key = next(iter(kwargs))
+        return f"(error) ValueError: unexpected keyword '{key}'"
+
+    try:
+        listing = diary_list_tree(_diary_paths(), rel_dir)
+    except Exception as e:
+        return f"(error) {type(e).__name__}: {e}"
+
+    return json.dumps(listing)
+
+
+@register("diary.mkdir", "Create a directory inside the diary root.")
+def diary_fn_mkdir(*args, **kwargs) -> str:
+    args = list(args)
+    kwargs = dict(kwargs)
+    try:
+        rel_dir = _get_param(args, kwargs, "rel_dir", cast=str)
+    except ValueError as e:
+        return f"(error) ValueError: {e}"
+
+    if rel_dir in ("", ".", ".."):
+        return "(error) ValueError: invalid directory name"
+
+    if args:
+        return "(error) ValueError: unexpected positional arguments"
+    if kwargs:
+        key = next(iter(kwargs))
+        return f"(error) ValueError: unexpected keyword '{key}'"
+
+    try:
+        created = diary_mkdir(_diary_paths(), rel_dir)
+    except Exception as e:
+        return f"(error) {type(e).__name__}: {e}"
+
+    return json.dumps({"path": created})
+
+
+@register("diary.move", "Move or rename diary files and directories.")
+def diary_fn_move(*args, **kwargs) -> str:
+    args = list(args)
+    kwargs = dict(kwargs)
+    try:
+        rel_src = _get_param(args, kwargs, "rel_src", cast=str)
+        rel_dst = _get_param(args, kwargs, "rel_dst", cast=str)
+        overwrite = _get_param(args, kwargs, "overwrite", default=False)
+    except ValueError as e:
+        return f"(error) ValueError: {e}"
+
+    if not isinstance(overwrite, bool):
+        return "(error) ValueError: overwrite must be a boolean"
+
+    if args:
+        return "(error) ValueError: unexpected positional arguments"
+    if kwargs:
+        key = next(iter(kwargs))
+        return f"(error) ValueError: unexpected keyword '{key}'"
+
+    try:
+        moved = diary_move(_diary_paths(), rel_src, rel_dst, overwrite=overwrite)
+    except Exception as e:
+        return f"(error) {type(e).__name__}: {e}"
+
+    return json.dumps({"path": moved})
+
+
+@register("diary.remove", "Delete a diary file or directory.")
+def diary_fn_remove(*args, **kwargs) -> str:
+    args = list(args)
+    kwargs = dict(kwargs)
+    try:
+        rel_path = _get_param(args, kwargs, "rel_path", cast=str)
+    except ValueError as e:
+        return f"(error) ValueError: {e}"
+
+    if args:
+        return "(error) ValueError: unexpected positional arguments"
+    if kwargs:
+        key = next(iter(kwargs))
+        return f"(error) ValueError: unexpected keyword '{key}'"
+
+    try:
+        removed = diary_remove(_diary_paths(), rel_path)
+    except Exception as e:
+        return f"(error) {type(e).__name__}: {e}"
+
+    return json.dumps({"removed": removed})
+
+
+def _validate_tag_list(name: str, value: Any) -> list[str]:
+    if not isinstance(value, list):
+        raise ValueError(f"{name} must be a list of strings")
+    result: list[str] = []
+    for item in value:
+        if not isinstance(item, str):
+            raise ValueError(f"{name} must be a list of strings")
+        result.append(item)
+    return result
+
+
+@register("diary.tags.get", "Get tags for a diary file.")
+def diary_tags_get(*args, **kwargs) -> str:
+    args = list(args)
+    kwargs = dict(kwargs)
+    try:
+        rel_file = _get_param(args, kwargs, "rel_file", cast=str)
+    except ValueError as e:
+        return f"(error) ValueError: {e}"
+
+    if args:
+        return "(error) ValueError: unexpected positional arguments"
+    if kwargs:
+        key = next(iter(kwargs))
+        return f"(error) ValueError: unexpected keyword '{key}'"
+
+    try:
+        tags = get_file_tags(_diary_paths(), rel_file)
+    except Exception as e:
+        return f"(error) {type(e).__name__}: {e}"
+
+    return json.dumps(tags)
+
+
+@register("diary.tags.add", "Add tags to a diary file.")
+def diary_tags_add(*args, **kwargs) -> str:
+    args = list(args)
+    kwargs = dict(kwargs)
+    try:
+        rel_file = _get_param(args, kwargs, "rel_file", cast=str)
+        tags_raw = _get_param(args, kwargs, "tags")
+        tags = _validate_tag_list("tags", tags_raw)
+    except ValueError as e:
+        return f"(error) ValueError: {e}"
+
+    if args:
+        return "(error) ValueError: unexpected positional arguments"
+    if kwargs:
+        key = next(iter(kwargs))
+        return f"(error) ValueError: unexpected keyword '{key}'"
+
+    try:
+        updated = add_file_tags(_diary_paths(), rel_file, tags)
+    except Exception as e:
+        return f"(error) {type(e).__name__}: {e}"
+
+    return json.dumps(updated)
+
+
+@register("diary.tags.remove", "Remove tags from a diary file.")
+def diary_tags_remove(*args, **kwargs) -> str:
+    args = list(args)
+    kwargs = dict(kwargs)
+    try:
+        rel_file = _get_param(args, kwargs, "rel_file", cast=str)
+        tags_raw = _get_param(args, kwargs, "tags")
+        tags = _validate_tag_list("tags", tags_raw)
+    except ValueError as e:
+        return f"(error) ValueError: {e}"
+
+    if args:
+        return "(error) ValueError: unexpected positional arguments"
+    if kwargs:
+        key = next(iter(kwargs))
+        return f"(error) ValueError: unexpected keyword '{key}'"
+
+    try:
+        updated = remove_file_tags(_diary_paths(), rel_file, tags)
+    except Exception as e:
+        return f"(error) {type(e).__name__}: {e}"
+
+    return json.dumps(updated)
+
+
+@register("diary.tags.set", "Replace tags for a diary file.")
+def diary_tags_set(*args, **kwargs) -> str:
+    args = list(args)
+    kwargs = dict(kwargs)
+    try:
+        rel_file = _get_param(args, kwargs, "rel_file", cast=str)
+        tags_raw = _get_param(args, kwargs, "tags")
+        tags = _validate_tag_list("tags", tags_raw)
+    except ValueError as e:
+        return f"(error) ValueError: {e}"
+
+    if args:
+        return "(error) ValueError: unexpected positional arguments"
+    if kwargs:
+        key = next(iter(kwargs))
+        return f"(error) ValueError: unexpected keyword '{key}'"
+
+    try:
+        updated = set_file_tags(_diary_paths(), rel_file, tags)
+    except Exception as e:
+        return f"(error) {type(e).__name__}: {e}"
+
+    return json.dumps(updated)
+
+
+@register("diary.tags.search", "Search diary files by tags.")
+def diary_tags_search(*args, **kwargs) -> str:
+    args = list(args)
+    kwargs = dict(kwargs)
+    try:
+        include_raw = _get_param(args, kwargs, "include", default=[])
+        exclude_raw = _get_param(args, kwargs, "exclude", default=[])
+        include = _validate_tag_list("include", include_raw)
+        exclude = _validate_tag_list("exclude", exclude_raw)
+    except ValueError as e:
+        return f"(error) ValueError: {e}"
+
+    if args:
+        return "(error) ValueError: unexpected positional arguments"
+    if kwargs:
+        key = next(iter(kwargs))
+        return f"(error) ValueError: unexpected keyword '{key}'"
+
+    try:
+        matches = diary_search_by_tags(_diary_paths(), include, exclude)
+    except Exception as e:
+        return f"(error) {type(e).__name__}: {e}"
+
+    return json.dumps(matches)
+
+
+@register("diary.tags.reindex", "Rebuild the diary tag index from sidecars.")
+def diary_tags_reindex(*args, **kwargs) -> str:
+    if args:
+        return "(error) ValueError: unexpected positional arguments"
+    if kwargs:
+        key = next(iter(kwargs))
+        return f"(error) ValueError: unexpected keyword '{key}'"
+
+    try:
+        count = diary_reindex(_diary_paths())
+    except Exception as e:
+        return f"(error) {type(e).__name__}: {e}"
+
+    return json.dumps({"indexed": count})
 
 
 @register("list_agents", "Return the names of all agents currently loaded.")

--- a/tests/test_diary_tags.py
+++ b/tests/test_diary_tags.py
@@ -1,0 +1,125 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from diary_tags import (
+    DiaryPaths,
+    add_file_tags,
+    get_file_tags,
+    list_tree,
+    load_index,
+    mkdir,
+    move,
+    reindex,
+    remove,
+    remove_file_tags,
+    search_by_tags,
+    set_file_tags,
+)
+
+
+def _make_paths(tmp_path: Path, *, doc_inside_diary: bool = False) -> DiaryPaths:
+    diary_root = tmp_path / "diary"
+    documentation_root = tmp_path / "documentation"
+    diary_root.mkdir(parents=True, exist_ok=True)
+    documentation_root.mkdir(parents=True, exist_ok=True)
+    if doc_inside_diary:
+        inner_doc = diary_root / "documentation"
+        inner_doc.mkdir(parents=True, exist_ok=True)
+        documentation_root = inner_doc
+    return DiaryPaths(diary_root=diary_root, documentation_root=documentation_root)
+
+
+def _write_file(paths: DiaryPaths, relative: str, content: str = "entry") -> Path:
+    file_path = paths.diary_root / relative
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    file_path.write_text(content, encoding="utf-8")
+    return file_path
+
+
+def test_path_escape_and_documentation_block(tmp_path):
+    paths = _make_paths(tmp_path)
+
+    with pytest.raises(PermissionError):
+        mkdir(paths, "../outside")
+
+    with pytest.raises(PermissionError):
+        list_tree(paths, "/absolute")
+
+    inner_paths = _make_paths(tmp_path / "nested", doc_inside_diary=True)
+    with pytest.raises(PermissionError):
+        mkdir(inner_paths, "documentation/new")
+
+
+def test_directory_operations(tmp_path):
+    paths = _make_paths(tmp_path)
+    mkdir(paths, "project")
+    _write_file(paths, "note.txt", "hello")
+
+    tree = list_tree(paths, ".")
+    assert tree["dirs"] == ["project"]
+    assert tree["files"] == ["note.txt"]
+
+    add_file_tags(paths, "note.txt", ["Focus"])  # create sidecar to move
+    moved = move(paths, "note.txt", "project/journal.txt")
+    assert moved == "project/journal.txt"
+    assert (paths.diary_root / "project" / "journal.txt").exists()
+    assert not (paths.diary_root / "note.txt").exists()
+    assert load_index(paths) == {"project/journal.txt": ["Focus"]}
+
+    removed = remove(paths, "project")
+    assert removed is True
+    assert not (paths.diary_root / "project").exists()
+    assert load_index(paths) == {}
+
+    assert remove(paths, "missing.txt") is False
+
+
+def test_tag_lifecycle_and_search(tmp_path):
+    paths = _make_paths(tmp_path)
+    _write_file(paths, "entry.md", "dear diary")
+
+    assert get_file_tags(paths, "entry.md") == []
+
+    tags = add_file_tags(paths, "entry.md", ["Focus", "daily"])
+    assert tags == ["daily", "Focus"]
+
+    tags = add_file_tags(paths, "entry.md", ["focus", "Plan"])
+    assert tags == ["daily", "Focus", "Plan"]
+
+    tags = remove_file_tags(paths, "entry.md", ["FOCUS"])
+    assert tags == ["daily", "Plan"]
+
+    tags = set_file_tags(paths, "entry.md", ["Alpha", "beta"])
+    assert tags == ["Alpha", "beta"]
+
+    _write_file(paths, "other.txt", "notes")
+    add_file_tags(paths, "other.txt", ["beta", "gamma"])
+
+    matches = search_by_tags(paths, include=["beta"])
+    assert matches == ["entry.md", "other.txt"]
+
+    matches = search_by_tags(paths, include=["beta"], exclude=["gamma"])
+    assert matches == ["entry.md"]
+
+
+def test_sidecar_and_index_persistence(tmp_path):
+    paths = _make_paths(tmp_path)
+    _write_file(paths, "persist.txt", "keep")
+    add_file_tags(paths, "persist.txt", ["Keep"])
+
+    # Simulate new process
+    paths2 = DiaryPaths(paths.diary_root, paths.documentation_root)
+    assert get_file_tags(paths2, "persist.txt") == ["Keep"]
+
+    index_path = paths.diary_root / ".fenra" / "tags_index.json"
+    assert index_path.exists()
+    index_data = json.loads(index_path.read_text(encoding="utf-8"))
+    assert index_data["files"] == {"persist.txt": ["Keep"]}
+
+    index_path.unlink()
+    count = reindex(paths2)
+    assert count == 1
+    rebuilt = json.loads(index_path.read_text(encoding="utf-8"))
+    assert rebuilt["files"] == {"persist.txt": ["Keep"]}


### PR DESCRIPTION
## Summary
- implement a diary-only filesystem helper module with tag sidecars and index management
- expose diary directory and tagging commands through the Fenra function registry
- add configuration path helper and diary tagging tests to cover security, lifecycle, and persistence

## Testing
- pytest tests/test_diary_tags.py

------
https://chatgpt.com/codex/tasks/task_e_68ffc683ded4832d89d74a4040d486fb