### PR TITLE
Return early when Fenra is asleep to avoid spurious calls

### DIFF
--- a/conductor.py
+++ b/conductor.py
@@ -34,6 +34,8 @@ from config_loader import (
     save_agents,
     save_state,
 )
+from fenra import awareness
+from fenra.awareness import AWARENESS_SLEEP_MESSAGE
 from runtime_utils import (
     init_global_logging,
     parse_log_level,
@@ -227,6 +229,113 @@ def delete_one_time_inject() -> str:
             logger.exception("UI refresh_inject_pending failed")
     return msg
 
+
+def _format_one_time_inject_block(text: str) -> str:
+    text = str(text or "").strip()
+    if not text:
+        return ""
+    return (
+        "\n\n----- Injected One-Time Message (will not persist) -----\n"
+        f"{text}\n"
+        "----- End Injected One-Time Message -----"
+    )
+
+
+def _collect_awareness_base_segments(agent: dict) -> dict[str, str]:
+    cls = CLASSES.get(agent.get("agent_class", ""), {}) or {}
+
+    ignore_global_system = bool(cls.get("ignore_global_system", False)) or bool(
+        agent.get("ignore_global_system", False)
+    )
+    ignore_global_pre = bool(cls.get("ignore_global_pre", False)) or bool(
+        agent.get("ignore_global_pre", False)
+    )
+    ignore_global_post = bool(cls.get("ignore_global_post", False)) or bool(
+        agent.get("ignore_global_post", False)
+    )
+
+    ignore_class_system = bool(agent.get("ignore_class_system", False))
+    ignore_class_pre = bool(agent.get("ignore_class_pre", False))
+    ignore_class_post = bool(agent.get("ignore_class_post", False))
+
+    segments = {
+        "system.global": "" if ignore_global_system else str(GLOBALS.get("system_prompt", "") or ""),
+        "system.class": "" if ignore_class_system else str(cls.get("system_prompt", "") or ""),
+        "system.agent": str(agent.get("system_prompt", "") or ""),
+        "pre.global": "" if ignore_global_pre else str(GLOBALS.get("pre_context_message", "") or ""),
+        "pre.class": "" if ignore_class_pre else str(cls.get("pre_context_message", "") or ""),
+        "pre.agent": str(agent.get("pre_context_message", "") or ""),
+        "post.global": "" if ignore_global_post else str(GLOBALS.get("post_context_message", "") or ""),
+        "post.class": "" if ignore_class_post else str(cls.get("post_context_message", "") or ""),
+        "post.agent": str(agent.get("post_context_message", "") or ""),
+    }
+    return segments
+
+
+def _awareness_all_off(aw: dict) -> bool:
+    return all(not bool(v) for v in (aw or {}).values())
+
+
+def _awareness_is_on(aw: dict, name: str) -> bool:
+    return bool((aw or {}).get(name, False))
+
+
+def _read_current_transcript() -> str:
+    path = os.path.join("chatlogs", "context_current.txt")
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return f.read()
+    except FileNotFoundError:
+        return ""
+    except Exception:
+        logger.exception("Failed to read current transcript from %s", path)
+        return ""
+
+
+def resolve_awareness_text(agent: dict, item: str) -> str:
+    """Return the text block associated with a single awareness item."""
+
+    if not agent or not item:
+        return ""
+
+    name = str(item)
+    try:
+        model_id, *_ = effective_params(agent)
+    except Exception:
+        return ""
+
+    base = _collect_awareness_base_segments(agent)
+
+    if name in base:
+        raw = str(base.get(name, "") or "")
+        combined = raw.strip()
+        if not combined:
+            return ""
+        return _expand_context_macros(combined, agent=agent, model_id=model_id)
+
+    if name == "directed_memory":
+        try:
+            return directed_memory_block_for_agent(agent["name"], agent["agent_class"])
+        except Exception:
+            return ""
+
+    if name == "one_time_inject":
+        pending = str((STATE or {}).get("one_time_inject") or "").strip()
+        return _format_one_time_inject_block(pending)
+
+    if name == "context.transcript":
+        return _read_current_transcript()
+
+    if name == "context.discord_queue":
+        try:
+            limit = int(GLOBALS.get("discord_history_limit", 10))
+        except Exception:
+            limit = 10
+        return _discord_transcript(limit)
+
+    return ""
+
+
 # ----------------------------------------------------------------------------
 # Run control (Start/Stop)
 # ----------------------------------------------------------------------------
@@ -335,6 +444,12 @@ def load_all_configs() -> None:
     except Exception as exc:
         logger.warning("state.json invalid; initializing new state: %s", exc)
         STATE = {}
+    try:
+        awareness_state = awareness.get_awareness()
+        STATE.setdefault("awareness", {})
+        STATE["awareness"] = dict(awareness_state)
+    except Exception:
+        STATE.setdefault("awareness", {})
     if not STATE.get("current_agent") and AGENTS:
         earliest = min(AGENTS, key=lambda a: a.get("created_at", ""))
         STATE["current_agent"] = earliest["name"]
@@ -896,36 +1011,81 @@ def step_agent(agent_name: str) -> Optional[str]:
     global CONTEXT
     os.makedirs("chatlogs", exist_ok=True)
     agent = AGENTS_BY_NAME[agent_name]
-    model_id, temp, system_text, pre, post = effective_params(agent)
-    inject = get_one_time_inject()
-    if inject:
-        set_one_time_inject("")
-        injected_block = (
-            "\n\n----- Injected One-Time Message (will not persist) -----\n"
-            f"{inject}\n"
-            "----- End Injected One-Time Message -----"
-        )
-        post = (post or "") + injected_block
-    # Ensure Directed Memories are appended as the very last context segment.
+    cls = CLASSES[agent["agent_class"]]
+    groups_target = list(agent.get("groups_out") or agent.get("groups_in") or [])
+    timestamp = datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S")
+    model_id, temp, *_ = effective_params(agent)
+    base_segments = _collect_awareness_base_segments(agent)
+    dm_block = ""
     try:
-        _dm_block = directed_memory_block_for_agent(agent["name"], agent["agent_class"])
-        if _dm_block:
-            post = "\n\n".join(filter(None, [post, _dm_block]))
+        dm_block = directed_memory_block_for_agent(agent["name"], agent["agent_class"])
     except Exception:
         # Do not fail the run due to DM issues
+        dm_block = ""
+    reads_q = bool(cls.get("reads_message_queue"))
+    aw = awareness.get_awareness()
+    try:
+        STATE.setdefault("awareness", {})
+        STATE["awareness"] = dict(aw)
+    except Exception:
         pass
-    # When an agent reads the message queue, it must see ONLY the queue as its context.
-    # No prior transcript or other context is included.
-    reads_q = bool(CLASSES[agent["agent_class"]].get("reads_message_queue"))
     if reads_q:
-        limit = int(GLOBALS.get("discord_history_limit", 10))
-        msg = _discord_transcript(limit)
-        if not msg.strip():
+        try:
+            limit = int(GLOBALS.get("discord_history_limit", 10))
+        except Exception:
+            limit = 10
+        msg_source = _discord_transcript(limit)
+        if not msg_source.strip():
             logger.debug("Queue empty for %s; skipping generation", agent["name"])
             nxt = select_next_agent(agent_name)
             return nxt["name"] if nxt else None
     else:
-        msg = CONTEXT
+        msg_source = CONTEXT
+
+    system_parts = [
+        base_segments.get("system.global", "") if _awareness_is_on(aw, "system.global") else "",
+        base_segments.get("system.class", "") if _awareness_is_on(aw, "system.class") else "",
+        base_segments.get("system.agent", "") if _awareness_is_on(aw, "system.agent") else "",
+    ]
+    system_base = "\n".join(filter(None, system_parts)).strip()
+    system_text = (
+        _expand_context_macros(system_base, agent=agent, model_id=model_id) if system_base else ""
+    )
+
+    pre_parts = [
+        base_segments.get("pre.global", "") if _awareness_is_on(aw, "pre.global") else "",
+        base_segments.get("pre.class", "") if _awareness_is_on(aw, "pre.class") else "",
+        base_segments.get("pre.agent", "") if _awareness_is_on(aw, "pre.agent") else "",
+    ]
+    pre_base = "\n".join(filter(None, pre_parts)).strip()
+    pre = _expand_context_macros(pre_base, agent=agent, model_id=model_id) if pre_base else ""
+
+    post_parts = [
+        base_segments.get("post.global", "") if _awareness_is_on(aw, "post.global") else "",
+        base_segments.get("post.class", "") if _awareness_is_on(aw, "post.class") else "",
+        base_segments.get("post.agent", "") if _awareness_is_on(aw, "post.agent") else "",
+    ]
+    post_base = "\n".join(filter(None, post_parts)).strip()
+    post = _expand_context_macros(post_base, agent=agent, model_id=model_id) if post_base else ""
+
+    one_time_inject_txt = ""
+    if _awareness_is_on(aw, "one_time_inject"):
+        pending_inject = get_one_time_inject()
+        if pending_inject:
+            one_time_inject_txt = _format_one_time_inject_block(pending_inject)
+            set_one_time_inject("")
+    if one_time_inject_txt:
+        post = (post or "") + one_time_inject_txt
+
+    directed_memory_txt = dm_block if dm_block and _awareness_is_on(aw, "directed_memory") else ""
+    if directed_memory_txt:
+        post = "\n\n".join(filter(None, [post, directed_memory_txt]))
+
+    if reads_q:
+        msg = msg_source if _awareness_is_on(aw, "context.discord_queue") else ""
+    else:
+        msg = msg_source if _awareness_is_on(aw, "context.transcript") else ""
+
     msg = trim_message_for_budget(
         model_id,
         system_text,
@@ -935,25 +1095,52 @@ def step_agent(agent_name: str) -> Optional[str]:
         GLOBALS.get("max_context_tokens", 8192),
     )
     prompt = "\n".join(filter(None, [pre, msg, post]))
+
     if UI is not None:
-       # Do not write the pre-gen “overview” blob to Agent Context.
-       # The runtime_utils JSON watcher will overwrite the panel with the *exact*
-       # payload that is POSTed to Ollama, which is what we want to display.
-       try:
-           UI.set_active_agent(agent["name"])
-       except Exception:
-           logger.exception("UI set_active_agent failed")
-    try:
-        reply = MODEL.generate_from_prompt(
-            prompt,
-            override_model=model_id,
-            override_temperature=temp,
-            system_text=system_text,
-        )
-    except Exception as exc:  # keep loop alive on Ollama/network errors
-        logger.exception("Generation failed for %s: %s", agent["name"], exc)
+        # Do not write the pre-gen “overview” blob to Agent Context.
+        # The runtime_utils JSON watcher will overwrite the panel with the *exact*
+        # payload that is POSTed to Ollama, which is what we want to display.
+        try:
+            UI.set_active_agent(agent["name"])
+        except Exception:
+            logger.exception("UI set_active_agent failed")
+
+    if _awareness_all_off(aw):
+        reply = AWARENESS_SLEEP_MESSAGE
+        visible = reply.strip()
+        globals()["_LAST_VISIBLE_OUTPUT"] = visible
+        entry = {
+            "sender": agent["name"],
+            "timestamp": timestamp,
+            "message": reply,
+            "groups": groups_target,
+        }
+        msgs = _load_messages_to_humans()
+        msgs.append(entry)
+        _save_messages_to_humans(msgs)
+        _append_human_log(entry)
+        if UI is not None:
+            try:
+                UI.log({"timestamp": timestamp, "sender": agent["name"], "message": reply})
+            except Exception:
+                logger.exception("UI log failed for sleep message")
+        override = STATE.pop("force_next_agent", None)
+        if isinstance(override, str) and override in AGENTS_BY_NAME:
+            return override
         nxt = select_next_agent(agent_name)
         return nxt["name"] if nxt else None
+    else:
+        try:
+            reply = MODEL.generate_from_prompt(
+                prompt,
+                override_model=model_id,
+                override_temperature=temp,
+                system_text=system_text,
+            )
+        except Exception as exc:  # keep loop alive on Ollama/network errors
+            logger.exception("Generation failed for %s: %s", agent["name"], exc)
+            nxt = select_next_agent(agent_name)
+            return nxt["name"] if nxt else None
     # Make the agent's *visible* output (with Fenra call markup stripped) available to Fenra functions.
     try:
         raw = reply or ""
@@ -992,10 +1179,6 @@ def step_agent(agent_name: str) -> Optional[str]:
                 for _, _, res in calls_log
             )
             reply = f"{reply.rstrip()}\n\n{results}" if reply else results
-
-    cls = CLASSES[agent["agent_class"]]
-    groups_target = list(agent.get("groups_out") or agent.get("groups_in") or [])
-    timestamp = datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S")
 
     # Always record the message to the “humans” log so the UI shows it.
     entry = {

--- a/conductor.py
+++ b/conductor.py
@@ -1086,6 +1086,13 @@ def step_agent(agent_name: str) -> Optional[str]:
     else:
         msg = msg_source if _awareness_is_on(aw, "context.transcript") else ""
 
+    if _awareness_all_off(aw):
+        # All inputs disabled: keep the agent running but give only the sleep message.
+        msg = AWARENESS_SLEEP_MESSAGE
+        pre = ""
+        post = ""
+        system_text = ""
+
     msg = trim_message_for_budget(
         model_id,
         system_text,
@@ -1105,41 +1112,17 @@ def step_agent(agent_name: str) -> Optional[str]:
         except Exception:
             logger.exception("UI set_active_agent failed")
 
-    if _awareness_all_off(aw):
-        reply = AWARENESS_SLEEP_MESSAGE
-        visible = reply.strip()
-        globals()["_LAST_VISIBLE_OUTPUT"] = visible
-        entry = {
-            "sender": agent["name"],
-            "timestamp": timestamp,
-            "message": reply,
-            "groups": groups_target,
-        }
-        msgs = _load_messages_to_humans()
-        msgs.append(entry)
-        _save_messages_to_humans(msgs)
-        _append_human_log(entry)
-        if UI is not None:
-            try:
-                UI.set_active_agent(agent["name"])
-            except Exception:
-                logger.exception("UI set_active_agent failed for sleep message")
-        # mark for the loop and stop here
-        STATE["awareness_sleep"] = True
-        save_state(STATE)
-        return None
-    else:
-        try:
-            reply = MODEL.generate_from_prompt(
-                prompt,
-                override_model=model_id,
-                override_temperature=temp,
-                system_text=system_text,
-            )
-        except Exception as exc:  # keep loop alive on Ollama/network errors
-            logger.exception("Generation failed for %s: %s", agent["name"], exc)
-            nxt = select_next_agent(agent_name)
-            return nxt["name"] if nxt else None
+    try:
+        reply = MODEL.generate_from_prompt(
+            prompt,
+            override_model=model_id,
+            override_temperature=temp,
+            system_text=system_text,
+        )
+    except Exception as exc:  # keep loop alive on Ollama/network errors
+        logger.exception("Generation failed for %s: %s", agent["name"], exc)
+        nxt = select_next_agent(agent_name)
+        return nxt["name"] if nxt else None
     # Make the agent's *visible* output (with Fenra call markup stripped) available to Fenra functions.
     try:
         raw = reply or ""
@@ -1306,13 +1289,6 @@ def run_loop(steps: Optional[int] = None) -> None:
         logger.info("Running agent %s", cur)
         nxt = step_agent(cur)
         count += 1
-        # awareness sleep short-circuit: stay on current agent without advancing
-        if STATE.get("awareness_sleep"):
-            STATE["awareness_sleep"] = False
-            save_state(STATE)
-            logger.info("Agent %s is asleep; staying on current agent.", cur)
-            time.sleep(1.0)
-            continue
         logger.info("Next agent: %s", nxt)
         time.sleep(0.2)
         if nxt:

--- a/conductor.py
+++ b/conductor.py
@@ -1121,14 +1121,13 @@ def step_agent(agent_name: str) -> Optional[str]:
         _append_human_log(entry)
         if UI is not None:
             try:
-                UI.log({"timestamp": timestamp, "sender": agent["name"], "message": reply})
+                UI.set_active_agent(agent["name"])
             except Exception:
-                logger.exception("UI log failed for sleep message")
-        override = STATE.pop("force_next_agent", None)
-        if isinstance(override, str) and override in AGENTS_BY_NAME:
-            return override
-        nxt = select_next_agent(agent_name)
-        return nxt["name"] if nxt else None
+                logger.exception("UI set_active_agent failed for sleep message")
+        # mark for the loop and stop here
+        STATE["awareness_sleep"] = True
+        save_state(STATE)
+        return None
     else:
         try:
             reply = MODEL.generate_from_prompt(
@@ -1306,8 +1305,15 @@ def run_loop(steps: Optional[int] = None) -> None:
                 logger.exception("UI pre-step update failed")
         logger.info("Running agent %s", cur)
         nxt = step_agent(cur)
-        logger.info("Next agent: %s", nxt)
         count += 1
+        # awareness sleep short-circuit: stay on current agent without advancing
+        if STATE.get("awareness_sleep"):
+            STATE["awareness_sleep"] = False
+            save_state(STATE)
+            logger.info("Agent %s is asleep; staying on current agent.", cur)
+            time.sleep(1.0)
+            continue
+        logger.info("Next agent: %s", nxt)
         time.sleep(0.2)
         if nxt:
             cur = nxt

--- a/config_loader.py
+++ b/config_loader.py
@@ -6,6 +6,7 @@ import os
 
 from pathlib import Path
 from typing import Any, Dict
+
 from config import CONF_DIR
 
 

--- a/fenra/__init__.py
+++ b/fenra/__init__.py
@@ -1,19 +1,26 @@
-"""Fenra package."""
+"""Fenra package with lazy accessors for directed memory helpers."""
 
-import directed_memory as _directed_memory
+from importlib import import_module
+from typing import Any
 
-DirectedMemory = _directed_memory.DirectedMemory
-DirectedMemoryStore = _directed_memory.DirectedMemoryStore
-directed_memories_path = _directed_memory.directed_memories_path
-directed_memory_block_for_agent = _directed_memory.directed_memory_block_for_agent
-format_directed_memories_block = _directed_memory.format_directed_memories_block
-get_store = _directed_memory.get_store
-
-__all__ = [
+_DM_EXPORTS = {
     "DirectedMemory",
     "DirectedMemoryStore",
     "directed_memories_path",
     "directed_memory_block_for_agent",
     "format_directed_memories_block",
     "get_store",
-]
+}
+
+__all__ = sorted(_DM_EXPORTS)
+
+
+def __getattr__(name: str) -> Any:
+    if name in _DM_EXPORTS:
+        module = import_module("directed_memory")
+        return getattr(module, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    return sorted(list(globals().keys()) + list(_DM_EXPORTS))

--- a/fenra/awareness.py
+++ b/fenra/awareness.py
@@ -1,0 +1,94 @@
+"""Awareness state helpers shared across Fenra runtime and UI."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+from config_loader import load_state, save_state
+
+AWARENESS_KEYS = [
+    "system.global",
+    "system.class",
+    "system.agent",
+    "pre.global",
+    "pre.class",
+    "pre.agent",
+    "post.global",
+    "post.class",
+    "post.agent",
+    "directed_memory",
+    "one_time_inject",
+    "context.transcript",
+    "context.discord_queue",
+]
+
+AWARENESS_SLEEP_MESSAGE = (
+    "You are currently asleep. Use *~awareness.list()~* to get a list of the inputs you can enable."
+)
+
+
+def _default_awareness() -> Dict[str, bool]:
+    return {name: False for name in AWARENESS_KEYS}
+
+
+def _safe_load_state() -> dict:
+    try:
+        return load_state()
+    except FileNotFoundError:
+        return {}
+    except Exception:
+        return {}
+
+
+def _normalize_awareness(data: dict | None) -> tuple[dict[str, bool], bool]:
+    source = data if isinstance(data, dict) else {}
+    normalized: dict[str, bool] = {}
+    changed = not isinstance(data, dict)
+    for key in AWARENESS_KEYS:
+        val = bool(source.get(key, False))
+        if source.get(key) is not val:
+            changed = True
+        normalized[key] = val
+    if set(source.keys()) - set(AWARENESS_KEYS):
+        changed = True
+    return normalized, changed
+
+
+def get_awareness() -> Dict[str, bool]:
+    """Load the persisted awareness mapping, ensuring all keys are present."""
+
+    state = _safe_load_state()
+    normalized, changed = _normalize_awareness(state.get("awareness"))
+    if "awareness" not in state or changed:
+        state = dict(state)
+        state["awareness"] = dict(normalized) if normalized else _default_awareness()
+        save_state(state)
+    return dict(normalized)
+
+
+def set_awareness(aw: dict) -> None:
+    """Persist a complete awareness mapping."""
+
+    state = _safe_load_state()
+    normalized, _ = _normalize_awareness(aw)
+    state = dict(state)
+    state["awareness"] = dict(normalized) if normalized else _default_awareness()
+    save_state(state)
+
+
+def set_key(name: str, value: bool) -> None:
+    """Update a single awareness flag and persist it."""
+
+    aw = get_awareness()
+    if name not in aw:
+        return
+    aw[name] = bool(value)
+    set_awareness(aw)
+
+
+def all_off() -> bool:
+    """Return True when every awareness flag is disabled."""
+
+    aw = get_awareness()
+    return all(not enabled for enabled in aw.values())
+

--- a/fenra_functions.py
+++ b/fenra_functions.py
@@ -26,6 +26,8 @@ from diary_tags import (
     set_file_tags,
 )
 from directed_memory import get_store
+from fenra import awareness
+from fenra.awareness import AWARENESS_KEYS
 
 
 # ---------------------------
@@ -230,6 +232,133 @@ def dispatch_expression(expr: str) -> tuple[str, bool, str, str]:
 # --------------------------------
 # Built-in/required Fenra functions
 # --------------------------------
+
+
+def _sync_awareness_state_to_conductor() -> None:
+    import importlib
+
+    try:
+        conductor = importlib.import_module("conductor")
+    except Exception:
+        return
+
+    try:
+        conductor.STATE.setdefault("awareness", {})
+        conductor.STATE["awareness"] = dict(awareness.get_awareness())
+    except Exception:
+        pass
+
+
+@register("awareness.list", "List awareness-controlled text inputs and their status.")
+def awareness_list(*args, **kwargs) -> str:
+    args = list(args)
+    kwargs = dict(kwargs)
+    if args:
+        return "(error) ValueError: unexpected positional arguments"
+    if kwargs:
+        key = next(iter(kwargs))
+        return f"(error) ValueError: unexpected keyword '{key}'"
+
+    state = awareness.get_awareness()
+    lines = [f"{name}: {'on' if state.get(name) else 'off'}" for name in AWARENESS_KEYS]
+
+    _sync_awareness_state_to_conductor()
+
+    return "\n".join(lines)
+
+
+@register("awareness.notice", "Enable a specific awareness-controlled text input.")
+def awareness_notice(*args, **kwargs) -> str:
+    args = list(args)
+    kwargs = dict(kwargs)
+    try:
+        item = _get_param(args, kwargs, "item", default=None, cast=str)
+    except ValueError as e:
+        return f"(error) ValueError: {e}"
+
+    if args:
+        return "(error) ValueError: unexpected positional arguments"
+    if kwargs:
+        key = next(iter(kwargs))
+        return f"(error) ValueError: unexpected keyword '{key}'"
+
+    name = (item or "").strip()
+    if name not in AWARENESS_KEYS:
+        return f"No such awareness item: {name or '<empty>'}."
+
+    awareness.set_key(name, True)
+    _sync_awareness_state_to_conductor()
+
+    return f"Noticed {name}."
+
+
+@register("awareness.ignore", "Disable a specific awareness-controlled text input.")
+def awareness_ignore(*args, **kwargs) -> str:
+    args = list(args)
+    kwargs = dict(kwargs)
+    try:
+        item = _get_param(args, kwargs, "item", default=None, cast=str)
+    except ValueError as e:
+        return f"(error) ValueError: {e}"
+
+    if args:
+        return "(error) ValueError: unexpected positional arguments"
+    if kwargs:
+        key = next(iter(kwargs))
+        return f"(error) ValueError: unexpected keyword '{key}'"
+
+    name = (item or "").strip()
+    if name not in AWARENESS_KEYS:
+        return f"No such awareness item: {name or '<empty>'}."
+
+    awareness.set_key(name, False)
+    _sync_awareness_state_to_conductor()
+
+    return f"Ignored {name}."
+
+
+@register("awareness.peek", "Return the text Fenra would supply for the requested awareness input.")
+def awareness_peek(*args, **kwargs) -> str:
+    import importlib
+
+    args = list(args)
+    kwargs = dict(kwargs)
+    try:
+        item = _get_param(args, kwargs, "item", default=None, cast=str)
+    except ValueError as e:
+        return f"(error) ValueError: {e}"
+
+    if args:
+        return "(error) ValueError: unexpected positional arguments"
+    if kwargs:
+        key = next(iter(kwargs))
+        return f"(error) ValueError: unexpected keyword '{key}'"
+
+    name = (item or "").strip()
+    if name not in AWARENESS_KEYS:
+        return f"No text for {name}."
+
+    try:
+        conductor = importlib.import_module("conductor")
+        if not getattr(conductor, "_CONFIGS_LOADED", False) and hasattr(conductor, "ensure_configs_loaded"):
+            conductor.ensure_configs_loaded()
+    except Exception as exc:
+        return f"(error) {type(exc).__name__}: {exc}"
+
+    agent_name = (getattr(conductor, "STATE", {}) or {}).get("current_agent")
+    if not isinstance(agent_name, str) or agent_name not in getattr(conductor, "AGENTS_BY_NAME", {}):
+        return f"No text for {name}."
+
+    agent = conductor.AGENTS_BY_NAME[agent_name]
+    try:
+        text = conductor.resolve_awareness_text(agent, name)
+    except Exception as exc:
+        return f"(error) {type(exc).__name__}: {exc}"
+
+    if not text:
+        return f"No text for {name}."
+
+    return text
 
 
 @register("list_functions", "List available Fenra functions.")

--- a/fenra_ui.py
+++ b/fenra_ui.py
@@ -33,6 +33,7 @@ from config_loader import (
     save_agents,
 )
 from pdv_utils import apply_and_persist_pdv_adjustments
+from fenra import awareness
 
 logger = logging.getLogger(__name__)
 
@@ -670,6 +671,11 @@ class FenraUI:
 
         self._refresh_inject_pending()
 
+        # ----- Awareness Tab -----
+        self.awareness_vars: dict[str, tk.BooleanVar] = {}
+        self._awareness_refresh_job = None
+        self._build_awareness_tab()
+
         # ----- Topology Tab -----
         topology_tab = ttk.Frame(self.notebook)
         self.notebook.add(topology_tab, text="Topology")
@@ -917,6 +923,12 @@ class FenraUI:
         self._config_watch_thread = None
 
     def _on_close(self) -> None:
+        if getattr(self, "_awareness_refresh_job", None) is not None:
+            try:
+                self.root.after_cancel(self._awareness_refresh_job)
+            except Exception:
+                pass
+            self._awareness_refresh_job = None
         self._stop_config_watcher()
         try:
             self.root.destroy()
@@ -2148,6 +2160,65 @@ class FenraUI:
 
         self._threadsafe(_put_back)
         self._refresh_inject_pending()
+
+    def _build_awareness_tab(self) -> None:
+        tab = ttk.Frame(self.notebook)
+        self.notebook.add(tab, text="Awareness")
+        self.awareness_tab = tab
+        self.awareness_vars = {}
+
+        ttk.Label(
+            tab,
+            text="Enable or disable text inputs supplied to agents.",
+        ).grid(row=0, column=0, sticky="w", padx=4, pady=(4, 2))
+
+        current = awareness.get_awareness()
+        row = 1
+        for name in awareness.AWARENESS_KEYS:
+            var = tk.BooleanVar(value=bool(current.get(name, False)))
+            chk = tk.Checkbutton(
+                tab,
+                text=name,
+                variable=var,
+                anchor="w",
+                command=lambda n=name, v=var: self._on_awareness_toggle(n, v),
+            )
+            chk.grid(row=row, column=0, sticky="w", padx=4, pady=1)
+            self.awareness_vars[name] = var
+            row += 1
+
+        ttk.Button(tab, text="Refresh", command=self.refresh_awareness_tab).grid(
+            row=row, column=0, sticky="w", padx=4, pady=(4, 8)
+        )
+        tab.columnconfigure(0, weight=1)
+        self._schedule_awareness_poll()
+
+    def _on_awareness_toggle(self, name: str, var: tk.BooleanVar) -> None:
+        awareness.set_key(name, bool(var.get()))
+        try:
+            c = _get_conductor()
+            if hasattr(c, "STATE"):
+                c.STATE.setdefault("awareness", {})
+                c.STATE["awareness"] = dict(awareness.get_awareness())
+        except Exception:
+            pass
+
+    def refresh_awareness_tab(self) -> None:
+        state = awareness.get_awareness()
+        for name, var in self.awareness_vars.items():
+            var.set(bool(state.get(name, False)))
+
+    def _schedule_awareness_poll(self) -> None:
+        if getattr(self, "_awareness_refresh_job", None) is not None:
+            try:
+                self.root.after_cancel(self._awareness_refresh_job)
+            except Exception:
+                pass
+        self._awareness_refresh_job = self.root.after(1500, self._poll_awareness_tab)
+
+    def _poll_awareness_tab(self) -> None:
+        self.refresh_awareness_tab()
+        self._schedule_awareness_poll()
 
     def _reload_model_choices(self) -> None:
         try:


### PR DESCRIPTION
## Summary
- ensure the conductor logs and returns after emitting the awareness sleep message so the embedded Fenra command is not executed
- reuse the agent class metadata earlier in the step flow while preserving next-agent selection when no inputs are enabled
- drop the overly specific type annotation for the awareness tab refresh job in the UI

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_69092b89f588832db37a114c4f12f9e4