### PR TITLE
Switch Fenra function call markers to bare tildes

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,26 +37,26 @@ Use the following global/system prompt so that agents emit Fenra function calls 
 ```
 You can call Fenra runtime functions by outputting EXACTLY one line containing ONLY a call wrapped like:
 
-*~function_name(arg1,arg2,kw="val")~*
+~function_name(arg1,arg2,kw="val")~
 
 HARD RULES:
-- The character immediately after `*~` and the character immediately before `~*` must not be whitespace. Whitespace inside the span is allowed.
+- The character immediately after the first `~` and the character immediately before the closing `~` must not be whitespace. Whitespace inside the span is allowed.
 - All string arguments MUST be in double quotes.
 - If a human-readable name contains spaces, you may keep the spaces or replace them with underscores (e.g., "New_Name"). The runtime will translate underscores back to spaces.
-- After you emit a function call, immediately echo the exact call on the next line without the *~ ~* markers, prefixed by `CALL:` and with no spaces. Example:
+- After you emit a function call, immediately echo the exact call on the next line without the surrounding `~` markers, prefixed by `CALL:` and with no spaces. Example:
 
-*~rename_agent("New_Name")~*
+~rename_agent("New_Name")~
 CALL:rename_agent("New_Name")
 
 - Do not insert any other text between the call and the CALL echo. If you do not need to call a function, reply normally.
-- Never output more than one *~ ... ~* call per turn unless explicitly instructed.
+- Never output more than one ~...~ call per turn unless explicitly instructed.
 
 Examples (valid):
-*~list_functions()~*
+~list_functions()~
 CALL:list_functions()
 
-*~rename_agent("Old_Name","New_Name")~*
+~rename_agent("Old_Name","New_Name")~
 CALL:rename_agent("Old_Name","New_Name")
 
-Why these constraints? Fenra extracts function-call spans strictly as `*~ ... ~*` and validates only that the characters touching the markers are non-whitespace before dispatching them via `fenra_functions.dispatch_expression(...)`. The runtime records each executed call in the Function Calls tab and appends a summary note to the agent reply, so the explicit `CALL:` echo keeps the exact invocation visible to humans reviewing the transcript.
+Why these constraints? Fenra extracts function-call spans strictly as `~ ... ~` and validates only that the characters touching the markers are non-whitespace before dispatching them via `fenra_functions.dispatch_expression(...)`. The runtime records each executed call in the Function Calls tab and appends a summary note to the agent reply, so the explicit `CALL:` echo keeps the exact invocation visible to humans reviewing the transcript.
 ```

--- a/conductor.py
+++ b/conductor.py
@@ -78,9 +78,9 @@ def _is_valid_call_span(span: str) -> bool:
 
 
 def _extract_pwsh_commands(text: str) -> list[str]:
-    """Extract *~...~* call spans that have no leading/trailing whitespace."""
+    """Extract ~...~ call spans that have no leading/trailing whitespace."""
 
-    spans = re.findall(r"\*~(.*?)~\*", text or "", flags=re.DOTALL)
+    spans = re.findall(r"~(.*?)~", text or "", flags=re.DOTALL)
     return [s for s in spans if _is_valid_call_span(s)]
 
 
@@ -957,13 +957,13 @@ def step_agent(agent_name: str) -> Optional[str]:
     # Make the agent's *visible* output (with Fenra call markup stripped) available to Fenra functions.
     try:
         raw = reply or ""
-        visible = re.sub(r"\*~.*?~\*", "", raw, flags=re.DOTALL).strip()
+        visible = re.sub(r"~.*?~", "", raw, flags=re.DOTALL).strip()
     except Exception:
         visible = (reply or "").strip()
 
     # Expose to fenra_functions via the conductor module namespace
     globals()["_LAST_VISIBLE_OUTPUT"] = visible
-    # Execute any Fenra function calls emitted by the agent as *~...~* blocks.
+    # Execute any Fenra function calls emitted by the agent as ~...~ blocks.
     commands = _extract_pwsh_commands(reply)
     calls_log: list[tuple[str, str, str]] = []
     if commands:

--- a/fenra_functions.py
+++ b/fenra_functions.py
@@ -178,7 +178,7 @@ def _list_files(folder: str) -> str:
 
 def dispatch_expression(expr: str) -> tuple[str, bool, str, str]:
     """
-    Dispatch a Fenra function expression found inside *~...~*.
+    Dispatch a Fenra function expression found inside ~...~.
     Returns (function_name_or_guess, found, result_string).
     - found=False when the name is not registered -> 'Function does not exist.'
     - found=True for executed or error-returning calls (errors are returned as strings).
@@ -620,7 +620,8 @@ def rename_agent(*args, **kwargs) -> str:
     """
     Rename the calling agent (1 arg) or rename the agent with Old_Name to New_Name (2 args).
 
-    IMPORTANT: Call spans only forbid whitespace touching the *~ or ~* markers,
+    IMPORTANT: Call spans only forbid whitespace touching the leading or trailing
+    tilde markers,
     so names may include spaces directly. Underscores are still accepted and are
     converted back to spaces for convenience.
     """
@@ -1603,7 +1604,7 @@ def speak_to_discord(*args, **kwargs) -> str:
         key = next(iter(kwargs))
         return f"(error) ValueError: unexpected keyword '{key}'"
 
-    # Fetch the message the user actually sees (with *~...~* stripped)
+    # Fetch the message the user actually sees (with ~...~ stripped)
     conductor = importlib.import_module("conductor")
     text = getattr(conductor, "_LAST_VISIBLE_OUTPUT", "")
     text = (text or "").strip()
@@ -1630,7 +1631,7 @@ register_details(
     [
         {
             "parameters": "",
-            "usage": "Send the agent's visible output (with any *~...~* removed) to Discord. Place *~speak_to_discord()~* at the end of your message.",
+            "usage": "Send the agent's visible output (with any ~...~ removed) to Discord. Place ~speak_to_discord()~ at the end of your message.",
             "returns": "The exact text that was sent to Discord, or an error description.",
         }
     ],

--- a/tests/test_function_call_spans.py
+++ b/tests/test_function_call_spans.py
@@ -25,29 +25,29 @@ import conductor
 
 
 def test_extract_allows_internal_whitespace():
-    text = '*~rename_agent("Agent Prime", reason="Needs rename")~*'
+    text = '~rename_agent("Agent Prime", reason="Needs rename")~'
     assert conductor._extract_pwsh_commands(text) == [
         'rename_agent("Agent Prime", reason="Needs rename")'
     ]
 
 
 def test_extract_rejects_whitespace_touching_markers():
-    text = '*~ rename_agent("Agent")~* and *~rename_agent("Agent") ~*'
+    text = '~ rename_agent("Agent")~ and ~rename_agent("Agent") ~'
     assert conductor._extract_pwsh_commands(text) == []
 
 
 def test_extract_rejects_newline_directly_after_open():
-    text = '*~\nrename_agent("Agent")~*'
+    text = '~\nrename_agent("Agent")~'
     assert conductor._extract_pwsh_commands(text) == []
 
 
 def test_extract_rejects_newline_directly_before_close():
-    text = '*~rename_agent("Agent")\n~*'
+    text = '~rename_agent("Agent")\n~'
     assert conductor._extract_pwsh_commands(text) == []
 
 
 def test_extract_allows_newlines_inside_span():
-    text = '*~rename_agent("Agent" + "\nPrime")~*'
+    text = '~rename_agent("Agent" + "\nPrime")~'
     assert conductor._extract_pwsh_commands(text) == [
         'rename_agent("Agent" + "\nPrime")'
     ]


### PR DESCRIPTION
## Summary
- update the conductor's function-call extraction to recognize tilde-wrapped spans and adjust visible output filtering
- refresh runtime function documentation and metadata to describe the new tilde syntax
- update regression tests and README guidance for the tilde-based call markers

## Testing
- pytest tests/test_function_call_spans.py

------
https://chatgpt.com/codex/tasks/task_e_690d38d8b5d0832d84a026bd20cecf06